### PR TITLE
[TASK] Adjust tests to updated guides

### DIFF
--- a/tests/integration/interface-link/expected/index.html
+++ b/tests/integration/interface-link/expected/index.html
@@ -15,10 +15,8 @@
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>
-,
-for short <a href="/index.html#typo3-cms-core-testinterface">TestInterface</a>
-!</p>
+            <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>,
+for short <a href="/index.html#typo3-cms-core-testinterface">TestInterface</a>!</p>
     </div>
 
 <!-- content end -->

--- a/tests/integration/interface-with-method/expected/index.html
+++ b/tests/integration/interface-with-method/expected/index.html
@@ -13,7 +13,7 @@
     <dd>
         <p>Lorem Ipsum Dolor!</p><dl class="php method">
     <dt class="sig sig-object php" id="setdate">
-        
+
 <span class="sig-name descname"><span class="pre">setDate</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">int $year</span></em>, <em class="sig-param"><span class="pre">int $month</span></em>, <em class="sig-param"><span class="pre">int $day</span></em><span class="sig-paren">)</span>
@@ -25,7 +25,7 @@
 </dl>
 <dl class="php method">
     <dt class="sig sig-object php" id="getdate">
-        
+
 <span class="sig-name descname"><span class="pre">getDate</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
@@ -40,10 +40,8 @@
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>
-,
-for short <a href="/index.html#typo3-cms-core-testinterface">TestInterface</a>
-!</p>
+            <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>,
+for short <a href="/index.html#typo3-cms-core-testinterface">TestInterface</a>!</p>
     </div>
 
 <!-- content end -->


### PR DESCRIPTION
With https://github.com/phpDocumentor/guides/pull/718 unwanted whitespace was removed from the standard templates of links, that also influence the display of :php:interface: textroles as those are displayed as standard links.