### PR TITLE
[FEATURE] Introduce modifiers for PHP methods

### DIFF
--- a/src/Directives/Php/MethodDirective.php
+++ b/src/Directives/Php/MethodDirective.php
@@ -12,16 +12,32 @@ use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use phpDocumentor\Guides\RestructuredText\TextRoles\GenericLinkProvider;
+use Psr\Log\LoggerInterface;
 use T3Docs\GuidesPhpDomain\Nodes\PhpMethodNode;
 use T3Docs\GuidesPhpDomain\PhpDomain\MethodNameService;
+use T3Docs\GuidesPhpDomain\PhpDomain\ModifierService;
 
 final class MethodDirective extends SubDirective
 {
+    /**
+     * @var string[]
+     */
+    private array $allowedModifiers = ['abstract', 'final', 'public', 'protected', 'private', 'final', 'static'];
+    /** @var list<list<string>>  */
+    private array $illegalCombinations = [
+        ['private', 'protected'],
+        ['private', 'public'],
+        ['protected', 'public'],
+        ['private', 'abstract'],
+        ['final', 'abstract'],
+    ];
     public function __construct(
         Rule $startingRule,
         GenericLinkProvider $genericLinkProvider,
         private readonly MethodNameService $methodNameService,
         private readonly AnchorReducer $anchorReducer,
+        private readonly LoggerInterface $logger,
+        private readonly ModifierService $modifierService,
     ) {
         parent::__construct($startingRule);
         $genericLinkProvider->addGenericLink($this->getName(), $this->getName());
@@ -40,10 +56,19 @@ final class MethodDirective extends SubDirective
         $name = $this->methodNameService->getMethodName(trim($directive->getData()));
         $id = $this->anchorReducer->reduceAnchor($name->toString());
 
+        $modifiers = $this->modifierService->getModifiersFromDirectiveOptions($directive, $this->allowedModifiers);
+
+        foreach ($this->illegalCombinations as $combination) {
+            if ($directive->hasOption($combination[0]) && $directive->hasOption($combination[1])) {
+                $this->logger->warning(sprintf('A PHP method cannot be %s and %s at the same time.', $combination[0], $combination[1]), $blockContext->getDocumentParserContext()->getLoggerInformation());
+            }
+        }
+
         return new PhpMethodNode(
             $id,
             $name,
             $collectionNode->getChildren(),
+            $modifiers
         );
     }
 }

--- a/src/Directives/Php/StaticMethodDirective.php
+++ b/src/Directives/Php/StaticMethodDirective.php
@@ -12,6 +12,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use phpDocumentor\Guides\RestructuredText\TextRoles\GenericLinkProvider;
+use Psr\Log\LoggerInterface;
 use T3Docs\GuidesPhpDomain\Nodes\PhpMethodNode;
 use T3Docs\GuidesPhpDomain\Nodes\PhpModifierNode;
 use T3Docs\GuidesPhpDomain\PhpDomain\MethodNameService;
@@ -23,6 +24,7 @@ final class StaticMethodDirective extends SubDirective
         GenericLinkProvider $genericLinkProvider,
         private readonly MethodNameService $methodNameService,
         private readonly AnchorReducer $anchorReducer,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct($startingRule);
         $genericLinkProvider->addGenericLink($this->getName(), $this->getName());
@@ -38,6 +40,10 @@ final class StaticMethodDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
+        $this->logger->warning(
+            'Directive `.. php:staticmethod::` is deprecated use directive `.. php:method::` with option `:static:` instead. ',
+            $blockContext->getDocumentParserContext()->getLoggerInformation()
+        );
         $name = $this->methodNameService->getMethodName(trim($directive->getData()));
         $id = $this->anchorReducer->reduceAnchor($name->toString());
 

--- a/tests/integration/class-with-staticmethod/expected/logs/warning.log
+++ b/tests/integration/class-with-staticmethod/expected/logs/warning.log
@@ -1,0 +1,1 @@
+app.WARNING: Directive `.. php:staticmethod::` is deprecated use directive `.. php:method::` with option `:static:` instead.  {"rst-file":"index.rst"} []

--- a/tests/integration/method-illegal-combinations/expected/index.html
+++ b/tests/integration/method-illegal-combinations/expected/index.html
@@ -1,0 +1,78 @@
+<!-- content start -->
+    <div class="section" id="php-method-with-allowed-modifier-combinations">
+    <h1>PHP method with allowed modifier combinations</h1>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething1"><span class="sig-name modifier"><span class="pre">abstract</span></span>
+ <span class="sig-name modifier"><span class="pre">final</span></span>
+ <span class="sig-name modifier"><span class="pre">final</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething1</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething2"><span class="sig-name modifier"><span class="pre">public</span></span>
+ <span class="sig-name modifier"><span class="pre">protected</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething2</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething3"><span class="sig-name modifier"><span class="pre">public</span></span>
+ <span class="sig-name modifier"><span class="pre">private</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething3</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething4"><span class="sig-name modifier"><span class="pre">protected</span></span>
+ <span class="sig-name modifier"><span class="pre">private</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething4</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething5"><span class="sig-name modifier"><span class="pre">abstract</span></span>
+ <span class="sig-name modifier"><span class="pre">private</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething5</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+    </div>
+
+<!-- content end -->

--- a/tests/integration/method-illegal-combinations/expected/logs/warning.log
+++ b/tests/integration/method-illegal-combinations/expected/logs/warning.log
@@ -1,0 +1,5 @@
+app.WARNING: A PHP method cannot be final and abstract at the same time. {"rst-file":"index.rst"} []
+app.WARNING: A PHP method cannot be protected and public at the same time. {"rst-file":"index.rst"} []
+app.WARNING: A PHP method cannot be private and public at the same time. {"rst-file":"index.rst"} []
+app.WARNING: A PHP method cannot be private and protected at the same time. {"rst-file":"index.rst"} []
+app.WARNING: A PHP method cannot be private and abstract at the same time. {"rst-file":"index.rst"} []

--- a/tests/integration/method-illegal-combinations/input/index.rst
+++ b/tests/integration/method-illegal-combinations/input/index.rst
@@ -1,0 +1,33 @@
+=============================================
+PHP method with allowed modifier combinations
+=============================================
+
+..  php:method:: doSomething1(string $whatever): string
+    :abstract:
+    :final:
+
+    Do something
+
+..  php:method:: doSomething2(string $whatever): string
+    :public:
+    :protected:
+
+    Do something
+
+..  php:method:: doSomething3(string $whatever): string
+    :public:
+    :private:
+
+    Do something
+
+..  php:method:: doSomething4(string $whatever): string
+    :protected:
+    :private:
+
+    Do something
+
+..  php:method:: doSomething5(string $whatever): string
+    :private:
+    :abstract:
+
+    Do something

--- a/tests/integration/method-legal-combinations/expected/index.html
+++ b/tests/integration/method-legal-combinations/expected/index.html
@@ -1,0 +1,143 @@
+<!-- content start -->
+    <div class="section" id="php-method-with-allowed-modifier-combinations">
+    <h1>PHP method with allowed modifier combinations</h1>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething1"><span class="sig-name modifier"><span class="pre">abstract</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething1</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething2"><span class="sig-name modifier"><span class="pre">final</span></span>
+ <span class="sig-name modifier"><span class="pre">final</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething2</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething3"><span class="sig-name modifier"><span class="pre">public</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething3</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething4"><span class="sig-name modifier"><span class="pre">protected</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething4</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething5"><span class="sig-name modifier"><span class="pre">private</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething5</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething6"><span class="sig-name modifier"><span class="pre">static</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething6</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething7"><span class="sig-name modifier"><span class="pre">public</span></span>
+ <span class="sig-name modifier"><span class="pre">static</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething7</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething8"><span class="sig-name modifier"><span class="pre">protected</span></span>
+ <span class="sig-name modifier"><span class="pre">static</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething8</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething9"><span class="sig-name modifier"><span class="pre">final</span></span>
+ <span class="sig-name modifier"><span class="pre">private</span></span>
+ <span class="sig-name modifier"><span class="pre">final</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething9</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+            <dl class="php method">
+    <dt class="sig sig-object php" id="dosomething10"><span class="sig-name modifier"><span class="pre">abstract</span></span>
+ <span class="sig-name modifier"><span class="pre">protected</span></span>
+
+<span class="sig-name descname"><span class="pre">doSomething10</span></span>
+<span class="sig-paren">(</span>
+<em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
+<em class="sig-returns"><span class="pre">: string</span></em>
+</dt>
+    <dd>
+        <p>Do something</p>
+    </dd>
+</dl>
+
+    </div>
+
+<!-- content end -->

--- a/tests/integration/method-legal-combinations/input/index.rst
+++ b/tests/integration/method-legal-combinations/input/index.rst
@@ -1,0 +1,58 @@
+=============================================
+PHP method with allowed modifier combinations
+=============================================
+
+..  php:method:: doSomething1(string $whatever): string
+    :abstract:
+
+    Do something
+
+..  php:method:: doSomething2(string $whatever): string
+    :final:
+
+    Do something
+
+..  php:method:: doSomething3(string $whatever): string
+    :public:
+
+    Do something
+
+..  php:method:: doSomething4(string $whatever): string
+    :protected:
+
+    Do something
+
+..  php:method:: doSomething5(string $whatever): string
+    :private:
+
+    Do something
+
+..  php:method:: doSomething6(string $whatever): string
+    :static:
+
+    Do something
+
+
+..  php:method:: doSomething7(string $whatever): string
+    :public:
+    :static:
+
+    Do something
+
+..  php:method:: doSomething8(string $whatever): string
+    :protected:
+    :static:
+
+    Do something
+
+..  php:method:: doSomething9(string $whatever): string
+    :private:
+    :final:
+
+    Do something
+
+..  php:method:: doSomething10(string $whatever): string
+    :protected:
+    :abstract:
+
+    Do something

--- a/tests/integration/static-method/expected/logs/warning.log
+++ b/tests/integration/static-method/expected/logs/warning.log
@@ -1,0 +1,1 @@
+app.WARNING: Directive `.. php:staticmethod::` is deprecated use directive `.. php:method::` with option `:static:` instead.  {"rst-file":"index.rst"} []


### PR DESCRIPTION
Warn when illegal combinations are used

Deprecate directive php:staticmethod in favor of
php:method with option `:static:`