### PR TITLE
[TASK] Adjust coding styles

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,15 +2,24 @@
 
 $finder = (new PhpCsFixer\Finder())
     ->in([
-        __DIR__ .'/src',
-        __DIR__ .'/tests'
-    ])
-;
+        __DIR__ . '/src',
+        __DIR__ . '/tests'
+    ]);
 
 return (new PhpCsFixer\Config())
     ->setRules([
-        '@PER-CS' => true,
+        '@PER-CS1.0' => true,
         '@PHP81Migration' => true,
+
+        // Already implemented PER-CS2 rules we opt-in explicitly
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'concat_space' => [
+            'spacing' => 'one'
+        ],
+        'function_declaration' => [
+            'closure_fn_spacing' => 'none',
+        ],
+        'method_argument_space' => true,
+        'single_line_empty_body' => true,
     ])
-    ->setFinder($finder)
-    ;
+    ->setFinder($finder);


### PR DESCRIPTION
These are now the same as in the render-guides project. We stick to PER-CS1 with the already available implemented changes for PER-CS2 - so there are no changes to the code for now. This prevents necessary code style adjustments when more rules are added for PER-CS2 in future releases of php-cs-fixer. We can opt-in to them explicitely if desired and switch later to PER-CS2 when the ruleset is completely available in php-cs-fixer