### PR TITLE
[TASK] Use version ^0.3 of phpdocumentator/guides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,18 +5,18 @@
     "type": "library",
     "homepage": "https://docs.typo3.org",
     "require": {
-        "phpdocumentor/guides": "dev-main",
-        "phpdocumentor/guides-restructured-text": "dev-main"
+        "phpdocumentor/guides": "^0.3",
+        "phpdocumentor/guides-restructured-text": "^0.3"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.39",
         "friendsofphp/php-cs-fixer": "^3.39",
-        "phpdocumentor/guides-cli": "dev-main",
+        "phpdocumentor/guides-cli": "^0.3",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10.56",
         "phpstan/phpstan-strict-rules": "^1.5",
         "phpunit/phpunit": "^10.4",
-        "rector/rector": "^0.19",
+        "rector/rector": "0.19.1",
         "symplify/phpstan-rules": "^12.4"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
I had to limit rector to 0.19.1 for now as 0.19.2 is failing with

[ERROR] Class "Rector\Core\ValueObject\PhpVersion" not found

Note: We do not have the composer.lock under version control in this library