### PR TITLE
[FEATURE] Make Fully Qualified name available in members node.

### DIFF
--- a/src/Directives/Php/ClassDirective.php
+++ b/src/Directives/Php/ClassDirective.php
@@ -19,6 +19,7 @@ use T3Docs\GuidesPhpDomain\PhpDomain\ModifierService;
 
 final class ClassDirective extends SubDirective
 {
+    use ComponentTrait;
     /**
      * @var string[]
      */
@@ -54,7 +55,7 @@ final class ClassDirective extends SubDirective
             $this->logger->warning('A PHP class cannot be abstract and final at the same time.', $blockContext->getLoggerInformation());
         }
 
-        return new PhpClassNode(
+        $node = new PhpClassNode(
             $id,
             $fqn,
             $collectionNode->getChildren(),
@@ -62,5 +63,9 @@ final class ClassDirective extends SubDirective
             [],
             $modifiers,
         );
+
+        $this->setParentsForMembers($collectionNode, $node);
+
+        return $node;
     }
 }

--- a/src/Directives/Php/ComponentTrait.php
+++ b/src/Directives/Php/ComponentTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace T3Docs\GuidesPhpDomain\Directives\Php;
+
+use phpDocumentor\Guides\Nodes\CollectionNode;
+use T3Docs\GuidesPhpDomain\Nodes\PhpComponentNode;
+use T3Docs\GuidesPhpDomain\Nodes\PhpMemberNode;
+
+trait ComponentTrait
+{
+    private function setParentsForMembers(CollectionNode $collectionNode, PhpComponentNode $node): void
+    {
+        foreach ($collectionNode->getChildren() as $child) {
+            if (!$child instanceof PhpMemberNode) {
+                continue;
+            }
+            $child->setParentComponent($node);
+        }
+    }
+}

--- a/src/Directives/Php/EnumDirective.php
+++ b/src/Directives/Php/EnumDirective.php
@@ -18,6 +18,7 @@ use T3Docs\GuidesPhpDomain\PhpDomain\FullyQualifiedNameService;
 
 final class EnumDirective extends SubDirective
 {
+    use ComponentTrait;
     public function __construct(
         Rule                                       $startingRule,
         GenericLinkProvider                        $genericLinkProvider,
@@ -59,7 +60,7 @@ final class EnumDirective extends SubDirective
             $type = $directive->getOption('type')->toString();
         }
 
-        return new PhpEnumNode(
+        $node = new PhpEnumNode(
             $id,
             $fqn,
             $collectionNode->getChildren(),
@@ -68,5 +69,8 @@ final class EnumDirective extends SubDirective
             [],
             $type,
         );
+
+        $this->setParentsForMembers($collectionNode, $node);
+        return $node;
     }
 }

--- a/src/Directives/Php/ExceptionDirective.php
+++ b/src/Directives/Php/ExceptionDirective.php
@@ -19,6 +19,7 @@ use T3Docs\GuidesPhpDomain\PhpDomain\ModifierService;
 
 final class ExceptionDirective extends SubDirective
 {
+    use ComponentTrait;
     /**
      * @var string[]
      */
@@ -54,7 +55,7 @@ final class ExceptionDirective extends SubDirective
             $this->logger->warning('A PHP class cannot be abstract and final at the same time.', $blockContext->getLoggerInformation());
         }
 
-        return new PhpExceptionNode(
+        $node = new PhpExceptionNode(
             $id,
             $fqn,
             $collectionNode->getChildren(),
@@ -62,5 +63,8 @@ final class ExceptionDirective extends SubDirective
             [],
             $modifiers,
         );
+
+        $this->setParentsForMembers($collectionNode, $node);
+        return $node;
     }
 }

--- a/src/Directives/Php/InterfaceDirective.php
+++ b/src/Directives/Php/InterfaceDirective.php
@@ -17,6 +17,7 @@ use T3Docs\GuidesPhpDomain\PhpDomain\FullyQualifiedNameService;
 
 final class InterfaceDirective extends SubDirective
 {
+    use ComponentTrait;
     public function __construct(
         Rule                                       $startingRule,
         GenericLinkProvider                        $genericLinkProvider,
@@ -41,13 +42,15 @@ final class InterfaceDirective extends SubDirective
         $fqn = $this->fullyQualifiedNameService->getFullyQualifiedName($name, true);
 
         $id = $this->anchorNormalizer->reduceAnchor($fqn->toString());
-
-        return new PhpInterfaceNode(
+        $node = new PhpInterfaceNode(
             $id,
             $fqn,
             $collectionNode->getChildren(),
             null,
             [],
         );
+
+        $this->setParentsForMembers($collectionNode, $node);
+        return $node;
     }
 }

--- a/src/Directives/Php/TraitDirective.php
+++ b/src/Directives/Php/TraitDirective.php
@@ -17,6 +17,7 @@ use T3Docs\GuidesPhpDomain\PhpDomain\FullyQualifiedNameService;
 
 final class TraitDirective extends SubDirective
 {
+    use ComponentTrait;
     public function __construct(
         Rule                                       $startingRule,
         GenericLinkProvider                        $genericLinkProvider,
@@ -40,13 +41,15 @@ final class TraitDirective extends SubDirective
         $name = trim($directive->getData());
         $fqn = $this->fullyQualifiedNameService->getFullyQualifiedName($name, true);
         $id = $this->anchorNormalizer->reduceAnchor($fqn->toString());
-
-        return new PhpTraitNode(
+        $node = new PhpTraitNode(
             $id,
             $fqn,
             $collectionNode->getChildren(),
             null,
             [],
         );
+
+        $this->setParentsForMembers($collectionNode, $node);
+        return $node;
     }
 }

--- a/src/Nodes/PhpMemberNode.php
+++ b/src/Nodes/PhpMemberNode.php
@@ -20,6 +20,7 @@ abstract class PhpMemberNode extends CompoundNode implements LinkTargetNode
         private readonly string $type,
         private readonly string $name,
         array $value = [],
+        private ?PhpComponentNode $parentComponent = null,
     ) {
         parent::__construct($value);
     }
@@ -42,7 +43,7 @@ abstract class PhpMemberNode extends CompoundNode implements LinkTargetNode
     }
     public function getLinkText(): string
     {
-        return $this->name;
+        return $this->getFullyQualifiedName();
     }
 
     public function getType(): string
@@ -53,5 +54,23 @@ abstract class PhpMemberNode extends CompoundNode implements LinkTargetNode
     public function getId(): string
     {
         return $this->id;
+    }
+
+    public function getParentComponent(): ?PhpComponentNode
+    {
+        return $this->parentComponent;
+    }
+
+    public function setParentComponent(?PhpComponentNode $parentComponent): void
+    {
+        $this->parentComponent = $parentComponent;
+    }
+
+    public function getFullyQualifiedName(): string
+    {
+        if ($this->parentComponent == null) {
+            return $this->getName();
+        }
+        return $this->parentComponent->getName()->toString() . '::' . $this->getName();
     }
 }

--- a/tests/integration/class-abstract/expected/index.html
+++ b/tests/integration/class-abstract/expected/index.html
@@ -1,21 +1,17 @@
 <!-- content start -->
     <div class="section" id="abstract-class">
             <h1>abstract class</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-abstracttest">
-        <span class="sig-name modifier"><span class="pre">abstract</span></span>
- <em class="property"><span class="pre">class</span> </em>
+        <span class="sig-name modifier"><span class="pre">abstract</span></span> <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">AbstractTest</span></span>
-<a class="headerlink" href="#typo3-cms-core-abstracttest" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">AbstractTest</span></span><a class="headerlink" href="#typo3-cms-core-abstracttest" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-final-abstract/expected/index.html
+++ b/tests/integration/class-final-abstract/expected/index.html
@@ -1,22 +1,17 @@
 <!-- content start -->
     <div class="section" id="abstract-final-class-causes-warning">
             <h1>abstract final class causes warning</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-test">
-        <span class="sig-name modifier"><span class="pre">abstract</span></span>
- <span class="sig-name modifier"><span class="pre">final</span></span>
- <em class="property"><span class="pre">class</span> </em>
+        <span class="sig-name modifier"><span class="pre">abstract</span></span> <span class="sig-name modifier"><span class="pre">final</span></span> <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">Test</span></span>
-<a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">Test</span></span><a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-final/expected/index.html
+++ b/tests/integration/class-final/expected/index.html
@@ -1,21 +1,17 @@
 <!-- content start -->
     <div class="section" id="final-class">
             <h1>final class</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-test">
-        <span class="sig-name modifier"><span class="pre">final</span></span>
- <em class="property"><span class="pre">class</span> </em>
+        <span class="sig-name modifier"><span class="pre">final</span></span> <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">Test</span></span>
-<a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">Test</span></span><a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-namespace-directive/expected/index.html
+++ b/tests/integration/class-namespace-directive/expected/index.html
@@ -1,46 +1,41 @@
 <!-- content start -->
     <div class="section" id="php-class-with-current-namespace-from-directive">
             <h1>PHP Class with current namespace from directive</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-testclass">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">TestClass</span></span>
-<a class="headerlink" href="#typo3-cms-core-testclass" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">TestClass</span></span><a class="headerlink" href="#typo3-cms-core-testclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-anotherclass">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">AnotherClass</span></span>
-<a class="headerlink" href="#typo3-cms-core-anotherclass" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">AnotherClass</span></span><a class="headerlink" href="#typo3-cms-core-anotherclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor Another!</p>
+
+    <p>Lorem Ipsum Dolor Another!</p>
+
     </dd>
 </dl>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="myvendor-some-namespace-anotherclass">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\MyVendor\Some\Namespace\</span></span>
-<span class="sig-name descname"><span class="pre">AnotherClass</span></span>
-<a class="headerlink" href="#myvendor-some-namespace-anotherclass" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">AnotherClass</span></span><a class="headerlink" href="#myvendor-some-namespace-anotherclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor Yet Another!</p>
+
+    <p>Lorem Ipsum Dolor Yet Another!</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-with-const-illegal-modifier-combinations/expected/index.html
+++ b/tests/integration/class-with-const-illegal-modifier-combinations/expected/index.html
@@ -1,56 +1,44 @@
 <!-- content start -->
     <div class="section" id="php-class-with-constants">
             <h1>PHP class with constants</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="chucklefactory-funclass">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\ChuckleFactory\</span></span>
-<span class="sig-name descname"><span class="pre">FunClass</span></span>
-<a class="headerlink" href="#chucklefactory-funclass" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">FunClass</span></span><a class="headerlink" href="#chucklefactory-funclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Where Fun Knows No Bounds!</p><dl class="php const">
+
+    <p>Where Fun Knows No Bounds!</p>
+<dl class="php const">
     <dt class="sig sig-object php" id="chucklefactory-funclass-joy-constant">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="sig-name modifier"><span class="pre">private</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <span class="sig-name modifier"><span class="pre">private</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">JOY_CONSTANT</span></span>
-
-        <a class="headerlink" href="#chucklefactory-funclass-joy-constant" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The constant that encapsulates pure joy and laughter. Whenever you need
-a pick-me-up, just access JOY_CONSTANT and let the chuckles begin.</p></dd>
-</dl>
-<dl class="php const">
+        <a class="headerlink" href="#chucklefactory-funclass-joy-constant" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The constant that encapsulates pure joy and laughter. Whenever you need
+a pick-me-up, just access JOY_CONSTANT and let the chuckles begin.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="chucklefactory-funclass-giggle-factor">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="sig-name modifier"><span class="pre">protected</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <span class="sig-name modifier"><span class="pre">protected</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">GIGGLE_FACTOR</span></span>
-
-        <a class="headerlink" href="#chucklefactory-funclass-giggle-factor" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>A dynamic constant that measures the giggle intensity in the ChuckleFactory.
-It&#039;s known to spontaneously increase during code reviews and coffee breaks.</p></dd>
-</dl>
-<dl class="php const">
+        <a class="headerlink" href="#chucklefactory-funclass-giggle-factor" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>A dynamic constant that measures the giggle intensity in the ChuckleFactory.
+It&#039;s known to spontaneously increase during code reviews and coffee breaks.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="chucklefactory-funclass-whimsical-wonder">
-        <span class="sig-name modifier"><span class="pre">protected</span></span>
- <span class="sig-name modifier"><span class="pre">private</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">protected</span></span> <span class="sig-name modifier"><span class="pre">private</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">WHIMSICAL_WONDER</span></span>
-
-        <a class="headerlink" href="#chucklefactory-funclass-whimsical-wonder" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Unleash the power of whimsy! This constant is your key to unlocking the
-whimsical wonders hidden within the FunClass. Expect surprises and delight!</p></dd>
+        <a class="headerlink" href="#chucklefactory-funclass-whimsical-wonder" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Unleash the power of whimsy! This constant is your key to unlocking the
+whimsical wonders hidden within the FunClass. Expect surprises and delight!</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-with-const-link-warning/expected/index.html
+++ b/tests/integration/class-with-const-link-warning/expected/index.html
@@ -1,57 +1,50 @@
 <!-- content start -->
     <div class="section" id="php-class-with-constants">
             <h1>PHP class with constants</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="secretsociety-enigmaticclass">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\SecretSociety\</span></span>
-<span class="sig-name descname"><span class="pre">EnigmaticClass</span></span>
-<a class="headerlink" href="#secretsociety-enigmaticclass" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">EnigmaticClass</span></span><a class="headerlink" href="#secretsociety-enigmaticclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Unveiling the mysteries of constants!</p><dl class="php const">
+
+    <p>Unveiling the mysteries of constants!</p>
+<dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-pi">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">PI</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-pi" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The eternal symbol representing the ratio of a circle&#039;s circumference
-to its diameter. Also used as the secret handshake among mathematicians.</p></dd>
-</dl>
-<dl class="php const">
+        <a class="headerlink" href="#secretsociety-enigmaticclass-pi" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The eternal symbol representing the ratio of a circle&#039;s circumference
+to its diameter. Also used as the secret handshake among mathematicians.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-secret-number">
-        <span class="sig-name modifier"><span class="pre">protected</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">protected</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">SECRET_NUMBER</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-secret-number" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>This constant holds the secret number known only to members of the
+        <a class="headerlink" href="#secretsociety-enigmaticclass-secret-number" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>This constant holds the secret number known only to members of the
 EnigmaticClass. Rumor has it, it&#039;s the combination to the ultimate
-treasure chest.</p></dd>
-</dl>
-<dl class="php const">
+treasure chest.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-eternal-flame">
-        <span class="sig-name modifier"><span class="pre">private</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">private</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">ETERNAL_FLAME</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-eternal-flame" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The eternal flame, kept alight by the power of mystical constants. Its
+        <a class="headerlink" href="#secretsociety-enigmaticclass-eternal-flame" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The eternal flame, kept alight by the power of mystical constants. Its
 warmth is known only to those who dare to delve into the deepest realms
-of code and cryptography.</p></dd>
+of code and cryptography.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#secretsociety-enigmaticclass-pi">SecretSociety\EnigmaticClass\PI</a> or
+    <p>See also <a href="/index.html#secretsociety-enigmaticclass-pi">SecretSociety\EnigmaticClass\PI</a> or
 <a href="/index.html#secretsociety-enigmaticclass-secret-number">\SecretSociety\EnigmaticClass-&gt;SECRET_NUMBER</a>.</p>
-    </div>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/class-with-const-link/expected/index.html
+++ b/tests/integration/class-with-const-link/expected/index.html
@@ -1,57 +1,50 @@
 <!-- content start -->
     <div class="section" id="php-class-with-constants">
             <h1>PHP class with constants</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="secretsociety-enigmaticclass">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\SecretSociety\</span></span>
-<span class="sig-name descname"><span class="pre">EnigmaticClass</span></span>
-<a class="headerlink" href="#secretsociety-enigmaticclass" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">EnigmaticClass</span></span><a class="headerlink" href="#secretsociety-enigmaticclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Unveiling the mysteries of constants!</p><dl class="php const">
+
+    <p>Unveiling the mysteries of constants!</p>
+<dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-pi">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">PI</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-pi" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The eternal symbol representing the ratio of a circle&#039;s circumference
-to its diameter. Also used as the secret handshake among mathematicians.</p></dd>
-</dl>
-<dl class="php const">
+        <a class="headerlink" href="#secretsociety-enigmaticclass-pi" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The eternal symbol representing the ratio of a circle&#039;s circumference
+to its diameter. Also used as the secret handshake among mathematicians.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-secret-number">
-        <span class="sig-name modifier"><span class="pre">protected</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">protected</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">SECRET_NUMBER</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-secret-number" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>This constant holds the secret number known only to members of the
+        <a class="headerlink" href="#secretsociety-enigmaticclass-secret-number" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>This constant holds the secret number known only to members of the
 EnigmaticClass. Rumor has it, it&#039;s the combination to the ultimate
-treasure chest.</p></dd>
-</dl>
-<dl class="php const">
+treasure chest.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-eternal-flame">
-        <span class="sig-name modifier"><span class="pre">private</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">private</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">ETERNAL_FLAME</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-eternal-flame" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The eternal flame, kept alight by the power of mystical constants. Its
+        <a class="headerlink" href="#secretsociety-enigmaticclass-eternal-flame" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The eternal flame, kept alight by the power of mystical constants. Its
 warmth is known only to those who dare to delve into the deepest realms
-of code and cryptography.</p></dd>
+of code and cryptography.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#secretsociety-enigmaticclass-pi">SecretSociety\EnigmaticClass::PI</a> or
+    <p>See also <a href="/index.html#secretsociety-enigmaticclass-pi">SecretSociety\EnigmaticClass::PI</a> or
 <a href="/index.html#secretsociety-enigmaticclass-secret-number">\SecretSociety\EnigmaticClass::SECRET_NUMBER</a>.</p>
-    </div>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/class-with-const/expected/index.html
+++ b/tests/integration/class-with-const/expected/index.html
@@ -1,55 +1,46 @@
 <!-- content start -->
     <div class="section" id="php-class-with-constants">
             <h1>PHP class with constants</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="secretsociety-enigmaticclass">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\SecretSociety\</span></span>
-<span class="sig-name descname"><span class="pre">EnigmaticClass</span></span>
-<a class="headerlink" href="#secretsociety-enigmaticclass" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">EnigmaticClass</span></span><a class="headerlink" href="#secretsociety-enigmaticclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Unveiling the mysteries of constants!</p><dl class="php const">
+
+    <p>Unveiling the mysteries of constants!</p>
+<dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-pi">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">PI</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-pi" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The eternal symbol representing the ratio of a circle&#039;s circumference
-to its diameter. Also used as the secret handshake among mathematicians.</p></dd>
-</dl>
-<dl class="php const">
+        <a class="headerlink" href="#secretsociety-enigmaticclass-pi" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The eternal symbol representing the ratio of a circle&#039;s circumference
+to its diameter. Also used as the secret handshake among mathematicians.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-secret-number">
-        <span class="sig-name modifier"><span class="pre">protected</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">protected</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">SECRET_NUMBER</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-secret-number" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>This constant holds the secret number known only to members of the
+        <a class="headerlink" href="#secretsociety-enigmaticclass-secret-number" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>This constant holds the secret number known only to members of the
 EnigmaticClass. Rumor has it, it&#039;s the combination to the ultimate
-treasure chest.</p></dd>
-</dl>
-<dl class="php const">
+treasure chest.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-eternal-flame">
-        <span class="sig-name modifier"><span class="pre">private</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">private</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">ETERNAL_FLAME</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-eternal-flame" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The eternal flame, kept alight by the power of mystical constants. Its
+        <a class="headerlink" href="#secretsociety-enigmaticclass-eternal-flame" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The eternal flame, kept alight by the power of mystical constants. Its
 warmth is known only to those who dare to delve into the deepest realms
-of code and cryptography.</p></dd>
+of code and cryptography.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-with-link/expected/index.html
+++ b/tests/integration/class-with-link/expected/index.html
@@ -1,44 +1,43 @@
 <!-- content start -->
     <div class="section" id="php-class-with-explicit-namespace">
             <h1>PHP Class with explicit namespace</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-test">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">Test</span></span>
-<a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">Test</span></span><a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p><dl class="php method">
+
+    <p>Lorem Ipsum Dolor!</p>
+<dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-test-setdate">
 <span class="sig-name descname"><span class="pre">setDate</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">int $year</span></em>, <em class="sig-param"><span class="pre">int $month</span></em>, <em class="sig-param"><span class="pre">int $day</span></em><span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-test-setdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-setdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Set the date.</p>
+
+    <p>Set the date.</p>
+
         </dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-test-getdate">
 <span class="sig-name descname"><span class="pre">getDate</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: int</span></em>
-<a class="headerlink" href="#typo3-cms-core-test-getdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-getdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Get the date.</p>
+
+    <p>Get the date.</p>
+
         </dd>
 </dl>
-
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-test">\TYPO3\CMS\Core\Test</a>.</p>
-    </div>
+    <p>See also <a href="/index.html#typo3-cms-core-test">\TYPO3\CMS\Core\Test</a>.</p>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/class-with-method-link-warning/expected/index.html
+++ b/tests/integration/class-with-method-link-warning/expected/index.html
@@ -1,46 +1,43 @@
 <!-- content start -->
     <div class="section" id="php-class-with-explicit-namespace">
             <h1>PHP Class with explicit namespace</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-test">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">Test</span></span>
-<a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">Test</span></span><a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p><dl class="php method">
+
+    <p>Lorem Ipsum Dolor!</p>
+<dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-test-setdate">
 <span class="sig-name descname"><span class="pre">setDate</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">int $year</span></em>, <em class="sig-param"><span class="pre">int $month</span></em>, <em class="sig-param"><span class="pre">int $day</span></em><span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-test-setdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-setdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Set the date.</p>
+
+    <p>Set the date.</p>
+
         </dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-test-getdate">
 <span class="sig-name descname"><span class="pre">getDate</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: int</span></em>
-<a class="headerlink" href="#typo3-cms-core-test-getdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-getdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Get the date.</p>
+
+    <p>Get the date.</p>
+
         </dd>
-</dl>
-<dl class="php class">
+</dl><dl class="php class">
     <dt class="sig sig-object php"
         id="illegalsubclass">
         <em class="property"><span class="pre">class</span> </em>
-        <span class="sig-name descname"><span class="pre">IllegalSubClass</span></span>
-<a class="headerlink" href="#illegalsubclass" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">IllegalSubClass</span></span><a class="headerlink" href="#illegalsubclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
         <dl class="php method">
     <dt class="sig sig-object php" id="illegalsubclass-getdate">
@@ -48,21 +45,18 @@
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: int</span></em>
-<a class="headerlink" href="#illegalsubclass-getdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#illegalsubclass-getdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
 
         </dd>
 </dl>
-
+    </dd>
+</dl>
     </dd>
 </dl>
 
-    </dd>
-</dl>
-
-            <p>\TYPO3\CMS\Core\Test:: or
+    <p>\TYPO3\CMS\Core\Test:: or
 <a href="/index.html#typo3-cms-core-test-getdate">\TYPO3\CMS\Core\Test-&gt;getDate</a>.</p>
-    </div>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/class-with-method-link/expected/index.html
+++ b/tests/integration/class-with-method-link/expected/index.html
@@ -1,45 +1,44 @@
 <!-- content start -->
     <div class="section" id="php-class-with-explicit-namespace">
             <h1>PHP Class with explicit namespace</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-test">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">Test</span></span>
-<a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">Test</span></span><a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p><dl class="php method">
+
+    <p>Lorem Ipsum Dolor!</p>
+<dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-test-setdate">
 <span class="sig-name descname"><span class="pre">setDate</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">int $year</span></em>, <em class="sig-param"><span class="pre">int $month</span></em>, <em class="sig-param"><span class="pre">int $day</span></em><span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-test-setdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-setdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Set the date.</p>
+
+    <p>Set the date.</p>
+
         </dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-test-getdate">
 <span class="sig-name descname"><span class="pre">getDate</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: int</span></em>
-<a class="headerlink" href="#typo3-cms-core-test-getdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-getdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Get the date.</p>
+
+    <p>Get the date.</p>
+
         </dd>
 </dl>
-
     </dd>
 </dl>
 
-            <p><a href="/index.html#typo3-cms-core-test-setdate">\TYPO3\CMS\Core\Test::setDate(int $year, int $month, int $day)</a> or
+    <p><a href="/index.html#typo3-cms-core-test-setdate">\TYPO3\CMS\Core\Test::setDate(int $year, int $month, int $day)</a> or
 <a href="/index.html#typo3-cms-core-test-getdate">\TYPO3\CMS\Core\Test::getDate</a>.</p>
-    </div>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/class-with-method/expected/index.html
+++ b/tests/integration/class-with-method/expected/index.html
@@ -1,43 +1,40 @@
 <!-- content start -->
     <div class="section" id="php-class-with-explicit-namespace">
             <h1>PHP Class with explicit namespace</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-test">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">Test</span></span>
-<a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">Test</span></span><a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p><dl class="php method">
+
+    <p>Lorem Ipsum Dolor!</p>
+<dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-test-setdate">
 <span class="sig-name descname"><span class="pre">setDate</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">int $year</span></em>, <em class="sig-param"><span class="pre">int $month</span></em>, <em class="sig-param"><span class="pre">int $day</span></em><span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-test-setdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-setdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Set the date.</p>
+
+    <p>Set the date.</p>
+
         </dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-test-getdate">
 <span class="sig-name descname"><span class="pre">getDate</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: int</span></em>
-<a class="headerlink" href="#typo3-cms-core-test-getdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-getdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Get the date.</p>
+
+    <p>Get the date.</p>
+
         </dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-with-property-link/expected/index.html
+++ b/tests/integration/class-with-property-link/expected/index.html
@@ -1,39 +1,34 @@
 <!-- content start -->
     <div class="section" id="php-class-with-properties">
             <h1>PHP class with properties</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="jollyelf">
         <em class="property"><span class="pre">class</span> </em>
-        <span class="sig-name descname"><span class="pre">JollyElf</span></span>
-<a class="headerlink" href="#jollyelf" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">JollyElf</span></span><a class="headerlink" href="#jollyelf" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Welcome to the magical workshop of JollyElves, spreading cheer and joy!</p><dl class="php property">
-    <dt class="sig sig-object php" id="jollyelf-festivehatcolor">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="pre">string</span> <span class="sig-name descname"><span class="pre">$festiveHatColor</span></span>
 
-        <a class="headerlink" href="#jollyelf-festivehatcolor" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The color of the elf&#039;s festive hat, radiating holiday spirit. Can
-Improve the <a href="/index.html#jollyelf-giftcount">JollyElf::$giftCount</a>.</p></dd>
-</dl>
+    <p>Welcome to the magical workshop of JollyElves, spreading cheer and joy!</p>
 <dl class="php property">
+    <dt class="sig sig-object php" id="jollyelf-festivehatcolor">
+        <span class="sig-name modifier"><span class="pre">public</span></span> <span class="pre">string</span> <span class="sig-name descname"><span class="pre">$festiveHatColor</span></span>
+        <a class="headerlink" href="#jollyelf-festivehatcolor" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The color of the elf&#039;s festive hat, radiating holiday spirit. Can
+Improve the <a href="/index.html#jollyelf-giftcount">JollyElf::$giftCount</a>.</p>
+</dd>
+</dl><dl class="php property">
     <dt class="sig sig-object php" id="jollyelf-giftcount">
-        <span class="sig-name modifier"><span class="pre">protected</span></span>
- <span class="pre">int</span> <span class="sig-name descname"><span class="pre">$giftCount</span></span>
-
-        <a class="headerlink" href="#jollyelf-giftcount" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The count of gifts wrapped by the JollyElf, a closely guarded secret.</p></dd>
+        <span class="sig-name modifier"><span class="pre">protected</span></span> <span class="pre">int</span> <span class="sig-name descname"><span class="pre">$giftCount</span></span>
+        <a class="headerlink" href="#jollyelf-giftcount" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The count of gifts wrapped by the JollyElf, a closely guarded secret.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#jollyelf-festivehatcolor">JollyElf::$festiveHatColor</a>.</p>
-    </div>
+    <p>See also <a href="/index.html#jollyelf-festivehatcolor">JollyElf::$festiveHatColor</a>.</p>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/class-with-property-warnings/expected/index.html
+++ b/tests/integration/class-with-property-warnings/expected/index.html
@@ -1,48 +1,37 @@
 <!-- content start -->
     <div class="section" id="php-class-with-properties-that-cause-warnings">
             <h1>PHP class with properties that cause warnings</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="grumpygoblin">
         <em class="property"><span class="pre">class</span> </em>
-        <span class="sig-name descname"><span class="pre">GrumpyGoblin</span></span>
-<a class="headerlink" href="#grumpygoblin" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">GrumpyGoblin</span></span><a class="headerlink" href="#grumpygoblin" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Welcome to the gloomy world of GrumpyGoblins, spreading grumbles and dissatisfaction!</p><dl class="php property">
+
+    <p>Welcome to the gloomy world of GrumpyGoblins, spreading grumbles and dissatisfaction!</p>
+<dl class="php property">
     <dt class="sig sig-object php" id="grumpygoblin-hiddensecret">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="sig-name modifier"><span class="pre">private</span></span>
- <span class="pre">string</span> <span class="sig-name descname"><span class="pre">$hiddenSecret</span></span>
-
-        <a class="headerlink" href="#grumpygoblin-hiddensecret" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The grumpy goblin&#039;s hidden secret. Publicly private - an illegal combination!</p></dd>
-</dl>
-<dl class="php property">
+        <span class="sig-name modifier"><span class="pre">public</span></span> <span class="sig-name modifier"><span class="pre">private</span></span> <span class="pre">string</span> <span class="sig-name descname"><span class="pre">$hiddenSecret</span></span>
+        <a class="headerlink" href="#grumpygoblin-hiddensecret" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The grumpy goblin&#039;s hidden secret. Publicly private - an illegal combination!</p>
+</dd>
+</dl><dl class="php property">
     <dt class="sig sig-object php" id="grumpygoblin-ancientcurse">
-        <span class="sig-name modifier"><span class="pre">static</span></span>
- <span class="sig-name modifier"><span class="pre">readonly</span></span>
- <span class="pre">bool</span> <span class="sig-name descname"><span class="pre">$ancientCurse</span></span>
-
-        <a class="headerlink" href="#grumpygoblin-ancientcurse" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The ancient curse haunting all GrumpyGoblins. A static readonly curse - an illegal combination!</p></dd>
-</dl>
-<dl class="php property">
+        <span class="sig-name modifier"><span class="pre">static</span></span> <span class="sig-name modifier"><span class="pre">readonly</span></span> <span class="pre">bool</span> <span class="sig-name descname"><span class="pre">$ancientCurse</span></span>
+        <a class="headerlink" href="#grumpygoblin-ancientcurse" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The ancient curse haunting all GrumpyGoblins. A static readonly curse - an illegal combination!</p>
+</dd>
+</dl><dl class="php property">
     <dt class="sig sig-object php" id="grumpygoblin-complaintbox">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="pre">string</span> <span class="sig-name descname"><span class="pre">$complaintBox</span></span>
-
-        <a class="headerlink" href="#grumpygoblin-complaintbox" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The deprecated complaint box, once used by GrumpyGoblins to voice their discontent.</p></dd>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <span class="pre">string</span> <span class="sig-name descname"><span class="pre">$complaintBox</span></span>
+        <a class="headerlink" href="#grumpygoblin-complaintbox" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The deprecated complaint box, once used by GrumpyGoblins to voice their discontent.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-with-property/expected/index.html
+++ b/tests/integration/class-with-property/expected/index.html
@@ -1,65 +1,51 @@
 <!-- content start -->
     <div class="section" id="php-class-with-properties">
             <h1>PHP class with properties</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="jollyelf">
         <em class="property"><span class="pre">class</span> </em>
-        <span class="sig-name descname"><span class="pre">JollyElf</span></span>
-<a class="headerlink" href="#jollyelf" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">JollyElf</span></span><a class="headerlink" href="#jollyelf" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Welcome to the magical workshop of JollyElves, spreading cheer and joy!</p><dl class="php property">
+
+    <p>Welcome to the magical workshop of JollyElves, spreading cheer and joy!</p>
+<dl class="php property">
     <dt class="sig sig-object php" id="jollyelf-festivehatcolor">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="pre">string</span> <span class="sig-name descname"><span class="pre">$festiveHatColor</span></span>
-
-        <a class="headerlink" href="#jollyelf-festivehatcolor" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The color of the elf&#039;s festive hat, radiating holiday spirit.</p></dd>
-</dl>
-<dl class="php property">
+        <span class="sig-name modifier"><span class="pre">public</span></span> <span class="pre">string</span> <span class="sig-name descname"><span class="pre">$festiveHatColor</span></span>
+        <a class="headerlink" href="#jollyelf-festivehatcolor" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The color of the elf&#039;s festive hat, radiating holiday spirit.</p>
+</dd>
+</dl><dl class="php property">
     <dt class="sig sig-object php" id="jollyelf-giftcount">
-        <span class="sig-name modifier"><span class="pre">protected</span></span>
- <span class="pre">int</span> <span class="sig-name descname"><span class="pre">$giftCount</span></span>
-
-        <a class="headerlink" href="#jollyelf-giftcount" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The count of gifts wrapped by the JollyElf, a closely guarded secret.</p></dd>
-</dl>
-<dl class="php property">
+        <span class="sig-name modifier"><span class="pre">protected</span></span> <span class="pre">int</span> <span class="sig-name descname"><span class="pre">$giftCount</span></span>
+        <a class="headerlink" href="#jollyelf-giftcount" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The count of gifts wrapped by the JollyElf, a closely guarded secret.</p>
+</dd>
+</dl><dl class="php property">
     <dt class="sig sig-object php" id="jollyelf-sleighbelljingle">
-        <span class="sig-name modifier"><span class="pre">private</span></span>
- <span class="pre">bool</span> <span class="sig-name descname"><span class="pre">$sleighBellJingle</span></span>
-
-        <a class="headerlink" href="#jollyelf-sleighbelljingle" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Whether the sleigh bells on the elf&#039;s shoes are jingling merrily.</p></dd>
-</dl>
-<dl class="php property">
+        <span class="sig-name modifier"><span class="pre">private</span></span> <span class="pre">bool</span> <span class="sig-name descname"><span class="pre">$sleighBellJingle</span></span>
+        <a class="headerlink" href="#jollyelf-sleighbelljingle" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Whether the sleigh bells on the elf&#039;s shoes are jingling merrily.</p>
+</dd>
+</dl><dl class="php property">
     <dt class="sig sig-object php" id="jollyelf-totalgiftswrapped">
-        <span class="sig-name modifier"><span class="pre">static</span></span>
- <span class="pre">int</span> <span class="sig-name descname"><span class="pre">$totalGiftsWrapped</span></span>
-
-        <a class="headerlink" href="#jollyelf-totalgiftswrapped" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The total count of gifts wrapped by all JollyElves in the workshop.</p></dd>
-</dl>
-<dl class="php property">
+        <span class="sig-name modifier"><span class="pre">static</span></span> <span class="pre">int</span> <span class="sig-name descname"><span class="pre">$totalGiftsWrapped</span></span>
+        <a class="headerlink" href="#jollyelf-totalgiftswrapped" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The total count of gifts wrapped by all JollyElves in the workshop.</p>
+</dd>
+</dl><dl class="php property">
     <dt class="sig sig-object php" id="jollyelf-entryyear">
-        <span class="sig-name modifier"><span class="pre">private</span></span>
- <span class="sig-name modifier"><span class="pre">readonly</span></span>
- <span class="pre">int</span> <span class="sig-name descname"><span class="pre">$entryYear</span></span>
-
-        <a class="headerlink" href="#jollyelf-entryyear" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The year the JollyElf joyfully joined the festive workshop.</p></dd>
+        <span class="sig-name modifier"><span class="pre">private</span></span> <span class="sig-name modifier"><span class="pre">readonly</span></span> <span class="pre">int</span> <span class="sig-name descname"><span class="pre">$entryYear</span></span>
+        <a class="headerlink" href="#jollyelf-entryyear" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The year the JollyElf joyfully joined the festive workshop.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-with-staticmethod/expected/index.html
+++ b/tests/integration/class-with-staticmethod/expected/index.html
@@ -1,33 +1,29 @@
 <!-- content start -->
     <div class="section" id="php-class-with-static-method">
             <h1>PHP Class with static method</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="typo3-cms-core-test">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">Test</span></span>
-<a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">Test</span></span><a class="headerlink" href="#typo3-cms-core-test" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p><dl class="php method">
-    <dt class="sig sig-object php" id="typo3-cms-core-test-dosomething"><span class="sig-name modifier"><span class="pre">static</span></span>
 
+    <p>Lorem Ipsum Dolor!</p>
+<dl class="php method">
+    <dt class="sig sig-object php" id="typo3-cms-core-test-dosomething"><span class="sig-name modifier"><span class="pre">static</span></span>
 <span class="sig-name descname"><span class="pre">doSomething</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#typo3-cms-core-test-dosomething" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-test-dosomething" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-with-typed-const/expected/index.html
+++ b/tests/integration/class-with-typed-const/expected/index.html
@@ -1,55 +1,46 @@
 <!-- content start -->
     <div class="section" id="php-class-with-constants">
             <h1>PHP class with constants</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="secretsociety-enigmaticclass">
         <em class="property"><span class="pre">class</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\SecretSociety\</span></span>
-<span class="sig-name descname"><span class="pre">EnigmaticClass</span></span>
-<a class="headerlink" href="#secretsociety-enigmaticclass" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">EnigmaticClass</span></span><a class="headerlink" href="#secretsociety-enigmaticclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Unveiling the mysteries of constants!</p><dl class="php const">
+
+    <p>Unveiling the mysteries of constants!</p>
+<dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-pi">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="pre">double</span> <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <span class="pre">double</span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">PI</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-pi" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The eternal symbol representing the ratio of a circle&#039;s circumference
-to its diameter. Also used as the secret handshake among mathematicians.</p></dd>
-</dl>
-<dl class="php const">
+        <a class="headerlink" href="#secretsociety-enigmaticclass-pi" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The eternal symbol representing the ratio of a circle&#039;s circumference
+to its diameter. Also used as the secret handshake among mathematicians.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-secret-number">
-        <span class="sig-name modifier"><span class="pre">protected</span></span>
- <span class="pre">int</span> <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">protected</span></span> <span class="pre">int</span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">SECRET_NUMBER</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-secret-number" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>This constant holds the secret number known only to members of the
+        <a class="headerlink" href="#secretsociety-enigmaticclass-secret-number" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>This constant holds the secret number known only to members of the
 EnigmaticClass. Rumor has it, it&#039;s the combination to the ultimate
-treasure chest.</p></dd>
-</dl>
-<dl class="php const">
+treasure chest.</p>
+</dd>
+</dl><dl class="php const">
     <dt class="sig sig-object php" id="secretsociety-enigmaticclass-eternal-flame">
-        <span class="sig-name modifier"><span class="pre">private</span></span>
- <span class="pre">string</span> <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">private</span></span> <span class="pre">string</span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">ETERNAL_FLAME</span></span>
-
-        <a class="headerlink" href="#secretsociety-enigmaticclass-eternal-flame" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The eternal flame, kept alight by the power of mystical constants. Its
+        <a class="headerlink" href="#secretsociety-enigmaticclass-eternal-flame" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The eternal flame, kept alight by the power of mystical constants. Its
 warmth is known only to those who dare to delve into the deepest realms
-of code and cryptography.</p></dd>
+of code and cryptography.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/class-without-namespace/expected/index.html
+++ b/tests/integration/class-without-namespace/expected/index.html
@@ -1,19 +1,16 @@
 <!-- content start -->
     <div class="section" id="php-class">
             <h1>PHP Class</h1>
-
             <dl class="php class">
     <dt class="sig sig-object php"
         id="testclass">
         <em class="property"><span class="pre">class</span> </em>
-        <span class="sig-name descname"><span class="pre">TestClass</span></span>
-<a class="headerlink" href="#testclass" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">TestClass</span></span><a class="headerlink" href="#testclass" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/enum-backed-with-cases/expected/index.html
+++ b/tests/integration/enum-backed-with-cases/expected/index.html
@@ -1,36 +1,31 @@
 <!-- content start -->
     <div class="section" id="php-enum-backed-with-cases">
             <h1>PHP Enum, backed, with cases</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="redsuit">
         <em class="property"><span class="pre">enum</span> </em>
-        <span class="sig-name descname"><span class="pre">RedSuit</span></span>
-<span class="pre"> : string</span> <a class="headerlink" href="#redsuit" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">RedSuit</span></span><span class="pre"> : string</span> <a class="headerlink" href="#redsuit" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>In playing cards, a suit is one of the categories into which the
-cards of a deck are divided.</p><dl class="php case">
+
+    <p>In playing cards, a suit is one of the categories into which the
+cards of a deck are divided.</p>
+<dl class="php case">
     <dt class="sig sig-object php" id="redsuit-hearts">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Hearts</span></span>
- : <span class="pre">&#039;H&#039;</span> <a class="headerlink" href="#redsuit-hearts" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Hearts is one of the four suits in playing cards.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Hearts</span></span> : <span class="pre">&#039;H&#039;</span> <a class="headerlink" href="#redsuit-hearts" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Hearts is one of the four suits in playing cards.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="redsuit-diamonds">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Diamonds</span></span>
- : <span class="pre">&#039;D&#039;</span> <a class="headerlink" href="#redsuit-diamonds" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Diamonds is one of the four suits in playing cards.</p></dd>
+        <span class="sig-name descname"><span class="pre">Diamonds</span></span> : <span class="pre">&#039;D&#039;</span> <a class="headerlink" href="#redsuit-diamonds" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Diamonds is one of the four suits in playing cards.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/enum-namespace-directive/expected/index.html
+++ b/tests/integration/enum-namespace-directive/expected/index.html
@@ -1,33 +1,29 @@
 <!-- content start -->
     <div class="section" id="php-enum-with-current-namespace-from-directive">
             <h1>PHP Enum with current namespace from directive</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="myvendor-myextension-someenum">
         <em class="property"><span class="pre">enum</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\MyVendor\MyExtension\</span></span>
-<span class="sig-name descname"><span class="pre">SomeEnum</span></span>
-<a class="headerlink" href="#myvendor-myextension-someenum" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">SomeEnum</span></span><a class="headerlink" href="#myvendor-myextension-someenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>some stuff</p>
+
+    <p>some stuff</p>
+
     </dd>
 </dl>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="myvendor-myextension-anotherenum">
         <em class="property"><span class="pre">enum</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\MyVendor\MyExtension\</span></span>
-<span class="sig-name descname"><span class="pre">AnotherEnum</span></span>
-<a class="headerlink" href="#myvendor-myextension-anotherenum" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">AnotherEnum</span></span><a class="headerlink" href="#myvendor-myextension-anotherenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>another stuff</p>
+
+    <p>another stuff</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/enum-with-cases-link/expected/index.html
+++ b/tests/integration/enum-with-cases-link/expected/index.html
@@ -1,54 +1,49 @@
 <!-- content start -->
     <div class="section" id="php-enum-with-const">
             <h1>PHP Enum with Const</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="suit">
         <em class="property"><span class="pre">enum</span> </em>
-        <span class="sig-name descname"><span class="pre">Suit</span></span>
-<a class="headerlink" href="#suit" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">Suit</span></span><a class="headerlink" href="#suit" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>In playing cards, a suit is one of the categories into which the
-cards of a deck are divided.</p><dl class="php case">
+
+    <p>In playing cards, a suit is one of the categories into which the
+cards of a deck are divided.</p>
+<dl class="php case">
     <dt class="sig sig-object php" id="suit-hearts">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Hearts</span></span>
- : <a class="headerlink" href="#suit-hearts" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Hearts is one of the four suits in playing cards. It is red
-just like <a href="/index.html#suit-diamonds">Suit::Diamonds</a>.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Hearts</span></span> : <a class="headerlink" href="#suit-hearts" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Hearts is one of the four suits in playing cards. It is red
+just like <a href="/index.html#suit-diamonds">Suit::Diamonds</a>.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="suit-diamonds">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Diamonds</span></span>
- : <a class="headerlink" href="#suit-diamonds" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Diamonds is one of the four suits in playing cards.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Diamonds</span></span> : <a class="headerlink" href="#suit-diamonds" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Diamonds is one of the four suits in playing cards.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="suit-clubs">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Clubs</span></span>
- : <a class="headerlink" href="#suit-clubs" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Clubs is one of the four suits in playing cards.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Clubs</span></span> : <a class="headerlink" href="#suit-clubs" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Clubs is one of the four suits in playing cards.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="suit-spades">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Spades</span></span>
- : <a class="headerlink" href="#suit-spades" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Spades is one of the four suits in playing cards.</p></dd>
+        <span class="sig-name descname"><span class="pre">Spades</span></span> : <a class="headerlink" href="#suit-spades" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Spades is one of the four suits in playing cards.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
 
-            <p><a href="/index.html#suit-spades">Spades</a> counts 12 points in Skat.</p>
-    </div>
+    <p><a href="/index.html#suit-spades">Spades</a> counts 12 points in Skat.</p>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/enum-with-cases/expected/index.html
+++ b/tests/integration/enum-with-cases/expected/index.html
@@ -1,52 +1,45 @@
 <!-- content start -->
     <div class="section" id="php-enum-with-const">
             <h1>PHP Enum with Const</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="suit">
         <em class="property"><span class="pre">enum</span> </em>
-        <span class="sig-name descname"><span class="pre">Suit</span></span>
-<a class="headerlink" href="#suit" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">Suit</span></span><a class="headerlink" href="#suit" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>In playing cards, a suit is one of the categories into which the
-cards of a deck are divided.</p><dl class="php case">
+
+    <p>In playing cards, a suit is one of the categories into which the
+cards of a deck are divided.</p>
+<dl class="php case">
     <dt class="sig sig-object php" id="suit-hearts">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Hearts</span></span>
- : <a class="headerlink" href="#suit-hearts" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Hearts is one of the four suits in playing cards.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Hearts</span></span> : <a class="headerlink" href="#suit-hearts" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Hearts is one of the four suits in playing cards.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="suit-diamonds">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Diamonds</span></span>
- : <a class="headerlink" href="#suit-diamonds" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Diamonds is one of the four suits in playing cards.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Diamonds</span></span> : <a class="headerlink" href="#suit-diamonds" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Diamonds is one of the four suits in playing cards.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="suit-clubs">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Clubs</span></span>
- : <a class="headerlink" href="#suit-clubs" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Clubs is one of the four suits in playing cards.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Clubs</span></span> : <a class="headerlink" href="#suit-clubs" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Clubs is one of the four suits in playing cards.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="suit-spades">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Spades</span></span>
- : <a class="headerlink" href="#suit-spades" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Spades is one of the four suits in playing cards.</p></dd>
+        <span class="sig-name descname"><span class="pre">Spades</span></span> : <a class="headerlink" href="#suit-spades" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Spades is one of the four suits in playing cards.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/enum-with-constant/expected/index.html
+++ b/tests/integration/enum-with-constant/expected/index.html
@@ -1,29 +1,25 @@
 <!-- content start -->
     <div class="section" id="php-enum-with-const">
             <h1>PHP Enum with Const</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="myvendor-myextension-someenum">
         <em class="property"><span class="pre">enum</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\MyVendor\MyExtension\</span></span>
-<span class="sig-name descname"><span class="pre">SomeEnum</span></span>
-<a class="headerlink" href="#myvendor-myextension-someenum" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">SomeEnum</span></span><a class="headerlink" href="#myvendor-myextension-someenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>some stuff</p><dl class="php const">
+
+    <p>some stuff</p>
+<dl class="php const">
     <dt class="sig sig-object php" id="myvendor-myextension-someenum-pi">
         <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">PI</span></span>
-
-        <a class="headerlink" href="#myvendor-myextension-someenum-pi" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>represents the ratio of a circle&#039;s circumference to its diameter</p></dd>
+        <a class="headerlink" href="#myvendor-myextension-someenum-pi" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>represents the ratio of a circle&#039;s circumference to its diameter</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/enum-with-link/expected/index.html
+++ b/tests/integration/enum-with-link/expected/index.html
@@ -1,35 +1,33 @@
 <!-- content start -->
     <div class="section" id="php-enum-with-current-namespace-from-directive">
             <h1>PHP Enum with current namespace from directive</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="myvendor-myextension-someenum">
         <em class="property"><span class="pre">enum</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\MyVendor\MyExtension\</span></span>
-<span class="sig-name descname"><span class="pre">SomeEnum</span></span>
-<a class="headerlink" href="#myvendor-myextension-someenum" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">SomeEnum</span></span><a class="headerlink" href="#myvendor-myextension-someenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>some stuff</p>
+
+    <p>some stuff</p>
+
     </dd>
 </dl>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="myvendor-myextension-anotherenum">
         <em class="property"><span class="pre">enum</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\MyVendor\MyExtension\</span></span>
-<span class="sig-name descname"><span class="pre">AnotherEnum</span></span>
-<a class="headerlink" href="#myvendor-myextension-anotherenum" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">AnotherEnum</span></span><a class="headerlink" href="#myvendor-myextension-anotherenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>another stuff</p>
+
+    <p>another stuff</p>
+
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#myvendor-myextension-someenum">\MyVendor\MyExtension\SomeEnum</a> or
+    <p>See also <a href="/index.html#myvendor-myextension-someenum">\MyVendor\MyExtension\SomeEnum</a> or
 <a href="/index.html#myvendor-myextension-anotherenum">AnotherEnum</a></p>
-    </div>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/enum-with-namespace/expected/index.html
+++ b/tests/integration/enum-with-namespace/expected/index.html
@@ -1,33 +1,29 @@
 <!-- content start -->
     <div class="section" id="php-enum-without-namespace-from-directive">
             <h1>PHP Enum without namespace from directive</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="myvendor-myextension-someenum">
         <em class="property"><span class="pre">enum</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\MyVendor\MyExtension\</span></span>
-<span class="sig-name descname"><span class="pre">SomeEnum</span></span>
-<a class="headerlink" href="#myvendor-myextension-someenum" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">SomeEnum</span></span><a class="headerlink" href="#myvendor-myextension-someenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>some stuff</p>
+
+    <p>some stuff</p>
+
     </dd>
 </dl>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="myvendor-myextension-anotherenum">
         <em class="property"><span class="pre">enum</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\MyVendor\MyExtension\</span></span>
-<span class="sig-name descname"><span class="pre">AnotherEnum</span></span>
-<a class="headerlink" href="#myvendor-myextension-anotherenum" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">AnotherEnum</span></span><a class="headerlink" href="#myvendor-myextension-anotherenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>another stuff</p>
+
+    <p>another stuff</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/enum-with-warnings/expected/index.html
+++ b/tests/integration/enum-with-warnings/expected/index.html
@@ -1,64 +1,54 @@
 <!-- content start -->
     <div class="section" id="php-enum-with-warnings">
             <h1>PHP Enum with Warnings</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="redsuit">
         <em class="property"><span class="pre">enum</span> </em>
-        <span class="sig-name descname"><span class="pre">RedSuit</span></span>
-<span class="pre"> : string</span> <a class="headerlink" href="#redsuit" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">RedSuit</span></span><span class="pre"> : string</span> <a class="headerlink" href="#redsuit" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>In playing cards, a suit is one of the categories into which the
-cards of a deck are divided.</p><dl class="php case">
+
+    <p>In playing cards, a suit is one of the categories into which the
+cards of a deck are divided.</p>
+<dl class="php case">
     <dt class="sig sig-object php" id="redsuit-hearts">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Hearts</span></span>
- : <span class="pre">&#039;H&#039;</span> <a class="headerlink" href="#redsuit-hearts" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Hearts is one of the four suits in playing cards.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Hearts</span></span> : <span class="pre">&#039;H&#039;</span> <a class="headerlink" href="#redsuit-hearts" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Hearts is one of the four suits in playing cards.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="redsuit-diamonds">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Diamonds</span></span>
- : <span class="pre">&#039;D&#039;</span> <a class="headerlink" href="#redsuit-diamonds" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Diamonds is one of the four suits in playing cards.</p></dd>
+        <span class="sig-name descname"><span class="pre">Diamonds</span></span> : <span class="pre">&#039;D&#039;</span> <a class="headerlink" href="#redsuit-diamonds" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Diamonds is one of the four suits in playing cards.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="blacksuit">
         <em class="property"><span class="pre">enum</span> </em>
-        <span class="sig-name descname"><span class="pre">BlackSuit</span></span>
-<span class="pre"> : string</span> <a class="headerlink" href="#blacksuit" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">BlackSuit</span></span><span class="pre"> : string</span> <a class="headerlink" href="#blacksuit" title="Permalink to this definition">¶</a>    </dt>
     <dd>
         <dl class="php case">
     <dt class="sig sig-object php" id="blacksuit-clubs-c">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Clubs : &#039;C&#039;</span></span>
- : <a class="headerlink" href="#blacksuit-clubs-c" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Clubs is one of the four suits in playing cards.</p></dd>
-</dl>
-<dl class="php case">
+        <span class="sig-name descname"><span class="pre">Clubs : &#039;C&#039;</span></span> : <a class="headerlink" href="#blacksuit-clubs-c" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Clubs is one of the four suits in playing cards.</p>
+</dd>
+</dl><dl class="php case">
     <dt class="sig sig-object php" id="blacksuit-spades-s">
         <em class="property"><span class="pre">case</span></em>
-        <span class="sig-name descname"><span class="pre">Spades : &#039;S&#039;</span></span>
- : <a class="headerlink" href="#blacksuit-spades-s" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>Spades is one of the four suits in playing cards.</p></dd>
+        <span class="sig-name descname"><span class="pre">Spades : &#039;S&#039;</span></span> : <a class="headerlink" href="#blacksuit-spades-s" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>Spades is one of the four suits in playing cards.</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/enum-without-namespace/expected/index.html
+++ b/tests/integration/enum-without-namespace/expected/index.html
@@ -1,31 +1,27 @@
 <!-- content start -->
     <div class="section" id="php-enum-without-namespace-from-directive">
             <h1>PHP Enum without namespace from directive</h1>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="someenum">
         <em class="property"><span class="pre">enum</span> </em>
-        <span class="sig-name descname"><span class="pre">SomeEnum</span></span>
-<a class="headerlink" href="#someenum" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">SomeEnum</span></span><a class="headerlink" href="#someenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>some stuff</p>
+
+    <p>some stuff</p>
+
     </dd>
 </dl>
-
             <dl class="php enum">
     <dt class="sig sig-object php"
         id="anotherenum">
         <em class="property"><span class="pre">enum</span> </em>
-        <span class="sig-name descname"><span class="pre">AnotherEnum</span></span>
-<a class="headerlink" href="#anotherenum" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">AnotherEnum</span></span><a class="headerlink" href="#anotherenum" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>another stuff</p>
+
+    <p>another stuff</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/exception-directive/expected/index.html
+++ b/tests/integration/exception-directive/expected/index.html
@@ -1,21 +1,18 @@
 <!-- content start -->
     <div class="section" id="php-exception">
             <h1>PHP Exception</h1>
-
             <dl class="php exception">
     <dt class="sig sig-object php"
         id="typo3-cms-core-exception-page-brokenrootlineexception">
         <em class="property"><span class="pre">exception</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\Exception\Page\</span></span>
-<span class="sig-name descname"><span class="pre">BrokenRootLineException</span></span>
-<a class="headerlink" href="#typo3-cms-core-exception-page-brokenrootlineexception" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">BrokenRootLineException</span></span><a class="headerlink" href="#typo3-cms-core-exception-page-brokenrootlineexception" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Exception for root line traversal when a page within the root line traversal
+
+    <p>Exception for root line traversal when a page within the root line traversal
 is missing / can not be resolved.</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/exception-with-link-deprecated/expected/index.html
+++ b/tests/integration/exception-with-link-deprecated/expected/index.html
@@ -1,22 +1,21 @@
 <!-- content start -->
     <div class="section" id="php-exception">
             <h1>PHP Exception</h1>
-
             <dl class="php exception">
     <dt class="sig sig-object php"
         id="typo3-cms-core-exception-page-brokenrootlineexception">
         <em class="property"><span class="pre">exception</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\Exception\Page\</span></span>
-<span class="sig-name descname"><span class="pre">BrokenRootLineException</span></span>
-<a class="headerlink" href="#typo3-cms-core-exception-page-brokenrootlineexception" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">BrokenRootLineException</span></span><a class="headerlink" href="#typo3-cms-core-exception-page-brokenrootlineexception" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Exception for root line traversal when a page within the root line traversal
+
+    <p>Exception for root line traversal when a page within the root line traversal
 is missing / can not be resolved.</p>
+
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-exception-page-brokenrootlineexception">\TYPO3\CMS\Core\Exception\Page\BrokenRootLineException</a>.</p>
-    </div>
+    <p>See also <a href="/index.html#typo3-cms-core-exception-page-brokenrootlineexception">\TYPO3\CMS\Core\Exception\Page\BrokenRootLineException</a>.</p>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/exception-with-link/expected/index.html
+++ b/tests/integration/exception-with-link/expected/index.html
@@ -1,22 +1,21 @@
 <!-- content start -->
     <div class="section" id="php-exception">
             <h1>PHP Exception</h1>
-
             <dl class="php exception">
     <dt class="sig sig-object php"
         id="typo3-cms-core-exception-page-brokenrootlineexception">
         <em class="property"><span class="pre">exception</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\Exception\Page\</span></span>
-<span class="sig-name descname"><span class="pre">BrokenRootLineException</span></span>
-<a class="headerlink" href="#typo3-cms-core-exception-page-brokenrootlineexception" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">BrokenRootLineException</span></span><a class="headerlink" href="#typo3-cms-core-exception-page-brokenrootlineexception" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Exception for root line traversal when a page within the root line traversal
+
+    <p>Exception for root line traversal when a page within the root line traversal
 is missing / can not be resolved.</p>
+
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-exception-page-brokenrootlineexception">\TYPO3\CMS\Core\Exception\Page\BrokenRootLineException</a>.</p>
-    </div>
+    <p>See also <a href="/index.html#typo3-cms-core-exception-page-brokenrootlineexception">\TYPO3\CMS\Core\Exception\Page\BrokenRootLineException</a>.</p>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/global-variable/expected/index.html
+++ b/tests/integration/global-variable/expected/index.html
@@ -1,19 +1,17 @@
 <!-- content start -->
     <div class="section" id="php-global-variable">
             <h1>PHP Global Variable</h1>
-
             <dl class="php global">
     <dt class="sig sig-object php"
         id="globals-tca">
         <em class="property"><span class="pre">global</span> </em>
         <span class="pre">$GLOBALS[&#039;TCA&#039;]</span>
-        <a class="headerlink" href="#globals-tca" title="Permalink to this definition">¶</a>
-    </dt>
+        <a class="headerlink" href="#globals-tca" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Contains the TYPO3 Configuration Array</p>
+
+    <p>Contains the TYPO3 Configuration Array</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/interface-implicit-namespace/expected/index.html
+++ b/tests/integration/interface-implicit-namespace/expected/index.html
@@ -1,20 +1,17 @@
 <!-- content start -->
     <div class="section" id="php-interface-with-implicit-namespace">
             <h1>PHP Interface with implicit namespace</h1>
-
             <dl class="php interface">
     <dt class="sig sig-object php"
         id="typo3-cms-core-testinterface">
         <em class="property"><span class="pre">interface</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">TestInterface</span></span>
-<a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">TestInterface</span></span><a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/interface-link/expected/index.html
+++ b/tests/integration/interface-link/expected/index.html
@@ -1,22 +1,21 @@
 <!-- content start -->
     <div class="section" id="php-interface-with-implicit-namespace">
             <h1>PHP Interface with implicit namespace</h1>
-
             <dl class="php interface">
     <dt class="sig sig-object php"
         id="typo3-cms-core-testinterface">
         <em class="property"><span class="pre">interface</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">TestInterface</span></span>
-<a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">TestInterface</span></span><a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>,
+    <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>,
 for short <a href="/index.html#typo3-cms-core-testinterface">TestInterface</a>!</p>
-    </div>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/interface-namespace-directive/expected/index.html
+++ b/tests/integration/interface-namespace-directive/expected/index.html
@@ -1,33 +1,29 @@
 <!-- content start -->
     <div class="section" id="php-interface-with-current-namespace-from-directive">
             <h1>PHP Interface with current namespace from directive</h1>
-
             <dl class="php interface">
     <dt class="sig sig-object php"
         id="typo3-cms-core-testinterface">
         <em class="property"><span class="pre">interface</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">TestInterface</span></span>
-<a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">TestInterface</span></span><a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
-
             <dl class="php interface">
     <dt class="sig sig-object php"
         id="typo3-cms-core-anotherinterface">
         <em class="property"><span class="pre">interface</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">AnotherInterface</span></span>
-<a class="headerlink" href="#typo3-cms-core-anotherinterface" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">AnotherInterface</span></span><a class="headerlink" href="#typo3-cms-core-anotherinterface" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor Another!</p>
+
+    <p>Lorem Ipsum Dolor Another!</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/interface-with-const/expected/index.html
+++ b/tests/integration/interface-with-const/expected/index.html
@@ -1,29 +1,25 @@
 <!-- content start -->
     <div class="section" id="php-interface-with-const">
             <h1>PHP Interface with const</h1>
-
             <dl class="php interface">
     <dt class="sig sig-object php"
         id="typo3-cms-core-testinterface">
         <em class="property"><span class="pre">interface</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">TestInterface</span></span>
-<a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">TestInterface</span></span><a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p><dl class="php const">
+
+    <p>Lorem Ipsum Dolor!</p>
+<dl class="php const">
     <dt class="sig sig-object php" id="typo3-cms-core-testinterface-atom">
         <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">ATOM</span></span>
-
-        <a class="headerlink" href="#typo3-cms-core-testinterface-atom" title="Permalink to this definition">¶</a>
-    </dt>
-    <dd><p>The ATOM</p></dd>
+        <a class="headerlink" href="#typo3-cms-core-testinterface-atom" title="Permalink to this definition">¶</a>    </dt>
+    <dd>
+    <p>The ATOM</p>
+</dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/interface-with-method/expected/index.html
+++ b/tests/integration/interface-with-method/expected/index.html
@@ -1,45 +1,44 @@
 <!-- content start -->
     <div class="section" id="php-interface-with-implicit-namespace">
             <h1>PHP Interface with implicit namespace</h1>
-
             <dl class="php interface">
     <dt class="sig sig-object php"
         id="typo3-cms-core-testinterface">
         <em class="property"><span class="pre">interface</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\</span></span>
-<span class="sig-name descname"><span class="pre">TestInterface</span></span>
-<a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">TestInterface</span></span><a class="headerlink" href="#typo3-cms-core-testinterface" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p><dl class="php method">
+
+    <p>Lorem Ipsum Dolor!</p>
+<dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-testinterface-setdate">
 <span class="sig-name descname"><span class="pre">setDate</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">int $year</span></em>, <em class="sig-param"><span class="pre">int $month</span></em>, <em class="sig-param"><span class="pre">int $day</span></em><span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-testinterface-setdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-testinterface-setdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Set the date.</p>
+
+    <p>Set the date.</p>
+
         </dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-testinterface-getdate">
 <span class="sig-name descname"><span class="pre">getDate</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: int</span></em>
-<a class="headerlink" href="#typo3-cms-core-testinterface-getdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-testinterface-getdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Get the date.</p>
+
+    <p>Get the date.</p>
+
         </dd>
 </dl>
-
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>,
+    <p>See also <a href="/index.html#typo3-cms-core-testinterface">\TYPO3\CMS\Core\TestInterface</a>,
 for short <a href="/index.html#typo3-cms-core-testinterface">TestInterface</a>!</p>
-    </div>
 
+    </div>
 <!-- content end -->

--- a/tests/integration/interface-without-namespace/expected/index.html
+++ b/tests/integration/interface-without-namespace/expected/index.html
@@ -1,19 +1,16 @@
 <!-- content start -->
     <div class="section" id="php-interface">
             <h1>PHP Interface</h1>
-
             <dl class="php interface">
     <dt class="sig sig-object php"
         id="testinterface">
         <em class="property"><span class="pre">interface</span> </em>
-        <span class="sig-name descname"><span class="pre">TestInterface</span></span>
-<a class="headerlink" href="#testinterface" title="Permalink to this definition">¶</a>
-    </dt>
+        <span class="sig-name descname"><span class="pre">TestInterface</span></span><a class="headerlink" href="#testinterface" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum Dolor!</p>
+
+    <p>Lorem Ipsum Dolor!</p>
+
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/method-illegal-combinations/expected/index.html
+++ b/tests/integration/method-illegal-combinations/expected/index.html
@@ -1,83 +1,70 @@
 <!-- content start -->
     <div class="section" id="php-method-with-allowed-modifier-combinations">
             <h1>PHP method with allowed modifier combinations</h1>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething1"><span class="sig-name modifier"><span class="pre">abstract</span></span>
- <span class="sig-name modifier"><span class="pre">final</span></span>
- <span class="sig-name modifier"><span class="pre">final</span></span>
-
+    <dt class="sig sig-object php" id="dosomething1"><span class="sig-name modifier"><span class="pre">abstract</span></span> <span class="sig-name modifier"><span class="pre">final</span></span> <span class="sig-name modifier"><span class="pre">final</span></span>
 <span class="sig-name descname"><span class="pre">doSomething1</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething1" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething1" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething2"><span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="sig-name modifier"><span class="pre">protected</span></span>
-
+    <dt class="sig sig-object php" id="dosomething2"><span class="sig-name modifier"><span class="pre">public</span></span> <span class="sig-name modifier"><span class="pre">protected</span></span>
 <span class="sig-name descname"><span class="pre">doSomething2</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething2" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething2" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething3"><span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="sig-name modifier"><span class="pre">private</span></span>
-
+    <dt class="sig sig-object php" id="dosomething3"><span class="sig-name modifier"><span class="pre">public</span></span> <span class="sig-name modifier"><span class="pre">private</span></span>
 <span class="sig-name descname"><span class="pre">doSomething3</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething3" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething3" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething4"><span class="sig-name modifier"><span class="pre">protected</span></span>
- <span class="sig-name modifier"><span class="pre">private</span></span>
-
+    <dt class="sig sig-object php" id="dosomething4"><span class="sig-name modifier"><span class="pre">protected</span></span> <span class="sig-name modifier"><span class="pre">private</span></span>
 <span class="sig-name descname"><span class="pre">doSomething4</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething4" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething4" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething5"><span class="sig-name modifier"><span class="pre">abstract</span></span>
- <span class="sig-name modifier"><span class="pre">private</span></span>
-
+    <dt class="sig sig-object php" id="dosomething5"><span class="sig-name modifier"><span class="pre">abstract</span></span> <span class="sig-name modifier"><span class="pre">private</span></span>
 <span class="sig-name descname"><span class="pre">doSomething5</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething5" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething5" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/method-legal-combinations/expected/index.html
+++ b/tests/integration/method-legal-combinations/expected/index.html
@@ -1,153 +1,135 @@
 <!-- content start -->
     <div class="section" id="php-method-with-allowed-modifier-combinations">
             <h1>PHP method with allowed modifier combinations</h1>
-
             <dl class="php method">
     <dt class="sig sig-object php" id="dosomething1"><span class="sig-name modifier"><span class="pre">abstract</span></span>
-
 <span class="sig-name descname"><span class="pre">doSomething1</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething1" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething1" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething2"><span class="sig-name modifier"><span class="pre">final</span></span>
- <span class="sig-name modifier"><span class="pre">final</span></span>
-
+    <dt class="sig sig-object php" id="dosomething2"><span class="sig-name modifier"><span class="pre">final</span></span> <span class="sig-name modifier"><span class="pre">final</span></span>
 <span class="sig-name descname"><span class="pre">doSomething2</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething2" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething2" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
     <dt class="sig sig-object php" id="dosomething3"><span class="sig-name modifier"><span class="pre">public</span></span>
-
 <span class="sig-name descname"><span class="pre">doSomething3</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething3" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething3" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
     <dt class="sig sig-object php" id="dosomething4"><span class="sig-name modifier"><span class="pre">protected</span></span>
-
 <span class="sig-name descname"><span class="pre">doSomething4</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething4" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething4" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
     <dt class="sig sig-object php" id="dosomething5"><span class="sig-name modifier"><span class="pre">private</span></span>
-
 <span class="sig-name descname"><span class="pre">doSomething5</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething5" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething5" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
     <dt class="sig sig-object php" id="dosomething6"><span class="sig-name modifier"><span class="pre">static</span></span>
-
 <span class="sig-name descname"><span class="pre">doSomething6</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething6" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething6" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething7"><span class="sig-name modifier"><span class="pre">public</span></span>
- <span class="sig-name modifier"><span class="pre">static</span></span>
-
+    <dt class="sig sig-object php" id="dosomething7"><span class="sig-name modifier"><span class="pre">public</span></span> <span class="sig-name modifier"><span class="pre">static</span></span>
 <span class="sig-name descname"><span class="pre">doSomething7</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething7" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething7" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething8"><span class="sig-name modifier"><span class="pre">protected</span></span>
- <span class="sig-name modifier"><span class="pre">static</span></span>
-
+    <dt class="sig sig-object php" id="dosomething8"><span class="sig-name modifier"><span class="pre">protected</span></span> <span class="sig-name modifier"><span class="pre">static</span></span>
 <span class="sig-name descname"><span class="pre">doSomething8</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething8" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething8" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething9"><span class="sig-name modifier"><span class="pre">final</span></span>
- <span class="sig-name modifier"><span class="pre">private</span></span>
- <span class="sig-name modifier"><span class="pre">final</span></span>
-
+    <dt class="sig sig-object php" id="dosomething9"><span class="sig-name modifier"><span class="pre">final</span></span> <span class="sig-name modifier"><span class="pre">private</span></span> <span class="sig-name modifier"><span class="pre">final</span></span>
 <span class="sig-name descname"><span class="pre">doSomething9</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething9" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething9" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
             <dl class="php method">
-    <dt class="sig sig-object php" id="dosomething10"><span class="sig-name modifier"><span class="pre">abstract</span></span>
- <span class="sig-name modifier"><span class="pre">protected</span></span>
-
+    <dt class="sig sig-object php" id="dosomething10"><span class="sig-name modifier"><span class="pre">abstract</span></span> <span class="sig-name modifier"><span class="pre">protected</span></span>
 <span class="sig-name descname"><span class="pre">doSomething10</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething10" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething10" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/method-returns-fieldlist/expected/index.html
+++ b/tests/integration/method-returns-fieldlist/expected/index.html
@@ -1,26 +1,25 @@
 <!-- content start -->
     <div class="section" id="php-methods-with-return-value">
             <h1>PHP methods with return value</h1>
-
             <dl class="php method">
     <dt class="sig sig-object php" id="getdate">
 <span class="sig-name descname"><span class="pre">getDate</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
-<a class="headerlink" href="#getdate" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#getdate" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Get the date.</p>
+
+    <p>Get the date.</p>
+
                     <dl class="field-list simple">
                 <dt class="field-even">Returns:</dt>
                 <dd class="field-even">
-                    <p>Either false on failure, or the datetime object for method chaining.</p>
+
+    <p>Either false on failure, or the datetime object for method chaining.</p>
 
                 </dd>
             </dl>
         </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/method-returns/expected/index.html
+++ b/tests/integration/method-returns/expected/index.html
@@ -1,26 +1,23 @@
 <!-- content start -->
     <div class="section" id="php-methods-with-return-value">
             <h1>PHP methods with return value</h1>
-
             <dl class="php method">
     <dt class="sig sig-object php" id="getsomething">
 <span class="sig-name descname"><span class="pre">getSomething</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
-<a class="headerlink" href="#getsomething" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#getsomething" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Lorem Ipsum</p>
+
+    <p>Lorem Ipsum</p>
+
                     <dl class="field-list simple">
                 <dt class="field-even">Returns:</dt>
                 <dd class="field-even">
                     Something not specified...
-
                 </dd>
             </dl>
         </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/static-method/expected/index.html
+++ b/tests/integration/static-method/expected/index.html
@@ -1,21 +1,18 @@
 <!-- content start -->
     <div class="section" id="php-static-method">
             <h1>PHP static method</h1>
-
             <dl class="php method">
     <dt class="sig sig-object php" id="dosomething"><span class="sig-name modifier"><span class="pre">static</span></span>
-
 <span class="sig-name descname"><span class="pre">doSomething</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">string $whatever</span></em><span class="sig-paren">)</span>
 <em class="sig-returns"><span class="pre">: string</span></em>
-<a class="headerlink" href="#dosomething" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#dosomething" title="Permalink to this definition">¶</a>    </dt>
     <dd>
-        <p>Do something</p>
+
+    <p>Do something</p>
+
         </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/trait-directive/expected/index.html
+++ b/tests/integration/trait-directive/expected/index.html
@@ -1,52 +1,39 @@
 <!-- content start -->
     <div class="section" id="php-trait">
             <h1>PHP Trait</h1>
-
             <dl class="php trait">
     <dt class="sig sig-object php"
         id="typo3-cms-core-context-contextawaretrait">
         <em class="property"><span class="pre">trait</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\Context\</span></span>
-<span class="sig-name descname"><span class="pre">ContextAwareTrait</span></span>
-<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">ContextAwareTrait</span></span><a class="headerlink" href="#typo3-cms-core-context-contextawaretrait" title="Permalink to this definition">¶</a>    </dt>
     <dd>
         <dl class="php const">
     <dt class="sig sig-object php" id="typo3-cms-core-context-contextawaretrait-flag-1">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">FLAG_1</span></span>
-
-        <a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-flag-1" title="Permalink to this definition">¶</a>
-    </dt>
+        <a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-flag-1" title="Permalink to this definition">¶</a>    </dt>
     <dd></dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-context-contextawaretrait-setcontext">
 <span class="sig-name descname"><span class="pre">setContext</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">Context $context</span></em><span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-setcontext" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-setcontext" title="Permalink to this definition">¶</a>    </dt>
     <dd>
 
         </dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-context-contextawaretrait-getcontext">
 <span class="sig-name descname"><span class="pre">getContext</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-getcontext" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-getcontext" title="Permalink to this definition">¶</a>    </dt>
     <dd>
 
         </dd>
 </dl>
-
     </dd>
 </dl>
-
     </div>
-
 <!-- content end -->

--- a/tests/integration/trait-with-link/expected/index.html
+++ b/tests/integration/trait-with-link/expected/index.html
@@ -1,53 +1,42 @@
 <!-- content start -->
     <div class="section" id="php-trait">
             <h1>PHP Trait</h1>
-
             <dl class="php trait">
     <dt class="sig sig-object php"
         id="typo3-cms-core-context-contextawaretrait">
         <em class="property"><span class="pre">trait</span> </em>
             <span class="sig-prename descclassname"><span class="pre">\TYPO3\CMS\Core\Context\</span></span>
-<span class="sig-name descname"><span class="pre">ContextAwareTrait</span></span>
-<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait" title="Permalink to this definition">¶</a>
-    </dt>
+<span class="sig-name descname"><span class="pre">ContextAwareTrait</span></span><a class="headerlink" href="#typo3-cms-core-context-contextawaretrait" title="Permalink to this definition">¶</a>    </dt>
     <dd>
         <dl class="php const">
     <dt class="sig sig-object php" id="typo3-cms-core-context-contextawaretrait-flag-1">
-        <span class="sig-name modifier"><span class="pre">public</span></span>
- <em class="property"><span class="pre">const</span></em>
+        <span class="sig-name modifier"><span class="pre">public</span></span> <em class="property"><span class="pre">const</span></em>
         <span class="sig-name descname"><span class="pre">FLAG_1</span></span>
-
-        <a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-flag-1" title="Permalink to this definition">¶</a>
-    </dt>
+        <a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-flag-1" title="Permalink to this definition">¶</a>    </dt>
     <dd></dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-context-contextawaretrait-setcontext">
 <span class="sig-name descname"><span class="pre">setContext</span></span>
 <span class="sig-paren">(</span>
 <em class="sig-param"><span class="pre">Context $context</span></em><span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-setcontext" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-setcontext" title="Permalink to this definition">¶</a>    </dt>
     <dd>
 
         </dd>
-</dl>
-<dl class="php method">
+</dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-context-contextawaretrait-getcontext">
 <span class="sig-name descname"><span class="pre">getContext</span></span>
 <span class="sig-paren">(</span>
 <span class="sig-paren">)</span>
-<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-getcontext" title="Permalink to this definition">¶</a>
-    </dt>
+<a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-getcontext" title="Permalink to this definition">¶</a>    </dt>
     <dd>
 
         </dd>
 </dl>
-
     </dd>
 </dl>
 
-            <p>See also <a href="/index.html#typo3-cms-core-context-contextawaretrait">\TYPO3\CMS\Core\Context\ContextAwareTrait</a>.</p>
-    </div>
+    <p>See also <a href="/index.html#typo3-cms-core-context-contextawaretrait">\TYPO3\CMS\Core\Context\ContextAwareTrait</a>.</p>
 
+    </div>
 <!-- content end -->


### PR DESCRIPTION
This is used to suggest a rst reference snippet in the render-guides.

I can then offer the following code in the suggest wizzard:

```
:php:method:`somemanual:\LibraryName\LibraryClassFinal::firstmethod`
```

Instead of something like this:

```
:php:method:`somemanual:libraryname-libraryclassfinal-firstmethod`
```

depends on https://github.com/TYPO3-Documentation/guides-php-domain/pull/42