### PR TITLE
[BUGFIX] Render an empty method or global body as a clean empty <dd>

### DIFF
--- a/resources/template/html/body/directive/php/global.html.twig
+++ b/resources/template/html/body/directive/php/global.html.twig
@@ -6,6 +6,6 @@
         {% include "body/directive/php/partials/linkToSnippet.html.twig" %}
     </dt>
     <dd>
-        {{ renderNode(node.value) }}
+        {{- renderNode(node.value) -}}
     </dd>
 </dl>

--- a/resources/template/html/body/directive/php/method.html.twig
+++ b/resources/template/html/body/directive/php/method.html.twig
@@ -7,8 +7,8 @@
         {% include "body/directive/php/partials/linkToSnippet.html.twig" %}
     </dt>
     <dd>
-        {{ renderNode(node.value) }}
-        {% if node.returnsDescription %}
+        {{- renderNode(node.value) -}}
+        {%- if node.returnsDescription %}
             <dl class="field-list simple">
                 <dt class="field-even">Returns</dt>
                 <dd class="field-even">

--- a/tests/integration/class-with-method-link-warning/expected/index.html
+++ b/tests/integration/class-with-method-link-warning/expected/index.html
@@ -57,9 +57,7 @@
 <em class="sig-returns"><span class="pre">: int</span></em>
          <a class="headerlink" href="#illegalsubclass-getdate" title="Permalink to this definition">¶</a>
     </dt>
-    <dd>
-
-        </dd>
+    <dd></dd>
 </dl>
     </dd>
 </dl>

--- a/tests/integration/trait-directive/expected/index.html
+++ b/tests/integration/trait-directive/expected/index.html
@@ -28,9 +28,7 @@
 <em class="sig-param"><span class="pre">Context $context</span></em><span class="sig-paren">)</span>
          <a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-setcontext" title="Permalink to this definition">¶</a>
     </dt>
-    <dd>
-
-        </dd>
+    <dd></dd>
 </dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-context-contextawaretrait-getcontext">
 <span class="sig-name descname"><span class="pre">getContext</span></span>
@@ -38,9 +36,7 @@
 <span class="sig-paren">)</span>
          <a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-getcontext" title="Permalink to this definition">¶</a>
     </dt>
-    <dd>
-
-        </dd>
+    <dd></dd>
 </dl>
     </dd>
 </dl>

--- a/tests/integration/trait-with-link/expected/index.html
+++ b/tests/integration/trait-with-link/expected/index.html
@@ -28,9 +28,7 @@
 <em class="sig-param"><span class="pre">Context $context</span></em><span class="sig-paren">)</span>
          <a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-setcontext" title="Permalink to this definition">¶</a>
     </dt>
-    <dd>
-
-        </dd>
+    <dd></dd>
 </dl><dl class="php method">
     <dt class="sig sig-object php" id="typo3-cms-core-context-contextawaretrait-getcontext">
 <span class="sig-name descname"><span class="pre">getContext</span></span>
@@ -38,9 +36,7 @@
 <span class="sig-paren">)</span>
          <a class="headerlink" href="#typo3-cms-core-context-contextawaretrait-getcontext" title="Permalink to this definition">¶</a>
     </dt>
-    <dd>
-
-        </dd>
+    <dd></dd>
 </dl>
     </dd>
 </dl>


### PR DESCRIPTION
## What

`method.html.twig` and `global.html.twig` wrap `renderNode(node.value)` in a multi-line `<dd>`, so a member with **no body** renders a `<dd>` that contains insignificant whitespace instead of an empty element:

```html
<!-- before -->
<dd>
        </dd>
```

`property.html.twig`, `const.html.twig` and `case.html.twig` already emit a whitespace-free `<dd>`. This applies the same Twig whitespace control (`{{- … -}}`, `{%- …`) to method and global, so an empty body collapses to a clean empty element:

```html
<!-- after -->
<dd></dd>
```

The change is whitespace-only; the rendered markup is otherwise identical.

## Why

A clean, truly-empty `<dd>` lets a theme detect and style a body-less member with plain CSS (`dd:empty` / `:has(> dd:empty)`). The TYPO3 docs theme renders each member as a Bootstrap-style panel; a body-less member currently shows an **empty white panel** under the header. With this change the theme can collapse it to a single header bar — see TYPO3-Documentation/render-guides#1078 (the property/const/case half of that fix already works precisely because those templates emit a whitespace-free `<dd>`).

## Verified rendering (via the TYPO3 docs theme)

An empty `global` and an empty `method`, with the docs theme extended to style `dl.php.method`/`dl.php.global` (measured: card height 50px = header + borders, `dd:empty` matches). A method **with** a body is unchanged.

**Before** — empty member bodies render as empty panels:

![before](https://raw.githubusercontent.com/CybotTM/guides-php-domain/a576ec63bf0e30959114bb34d7ee9daf064ca855/empty-member/before.png)

**After** — empty bodies collapse to a header bar; `withReturn()` keeps its body:

![after](https://raw.githubusercontent.com/CybotTM/guides-php-domain/a576ec63bf0e30959114bb34d7ee9daf064ca855/empty-member/after.png)

## Integration fixtures

Rebased onto current `main` (which restored a working test harness via #52), so the suite runs again. The whitespace change shifts the line grouping inside `<dd>` for the body-less members in three snapshots, which are regenerated in this PR:

- `tests/integration/trait-directive/expected/index.html`
- `tests/integration/trait-with-link/expected/index.html`
- `tests/integration/class-with-method-link-warning/expected/index.html`

The comparison is line-normalized, so the only effective diff is the empty `<dd>` collapse — no semantic change. Full suite passes locally (`48` integration + `6` unit tests green).

Refs: TYPO3-Documentation/render-guides#1078
