### PR TITLE
[TASK] Fix failing CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "ergebnis/composer-normalize": "^2.39",
         "friendsofphp/php-cs-fixer": "^3.39",
-        "phpdocumentor/guides-cli": "^0.3",
+        "phpdocumentor/guides-cli": "^1.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10.56",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/src/Compiler/NodeTransformers/MemberNodeTransformer.php
+++ b/src/Compiler/NodeTransformers/MemberNodeTransformer.php
@@ -7,7 +7,6 @@ namespace T3Docs\GuidesPhpDomain\Compiler\NodeTransformers;
 use phpDocumentor\Guides\Compiler\CompilerContext;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
 use phpDocumentor\Guides\Nodes\Node;
-
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
 use Psr\Log\LoggerInterface;
 use T3Docs\GuidesPhpDomain\Nodes\PhpComponentNode;

--- a/src/DependencyInjection/GuidesPhpDomainExtension.php
+++ b/src/DependencyInjection/GuidesPhpDomainExtension.php
@@ -17,7 +17,6 @@ use T3Docs\GuidesPhpDomain\Nodes\PhpGlobalNode;
 use T3Docs\GuidesPhpDomain\Nodes\PhpMethodNode;
 use T3Docs\GuidesPhpDomain\Nodes\PhpModifierNode;
 use T3Docs\GuidesPhpDomain\Nodes\PhpNamespaceNode;
-
 use T3Docs\GuidesPhpDomain\Nodes\PhpPropertyNode;
 
 use function dirname;

--- a/src/Nodes/PhpCaseNode.php
+++ b/src/Nodes/PhpCaseNode.php
@@ -18,7 +18,7 @@ final class PhpCaseNode extends PhpMemberNode
         private readonly MemberNameNode $memberName,
         array                           $value = [],
         private readonly string|null    $backedValue = null,
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $memberName->toString(), $value, null, $noindex);
     }

--- a/src/Nodes/PhpClassNode.php
+++ b/src/Nodes/PhpClassNode.php
@@ -21,7 +21,7 @@ final class PhpClassNode extends PhpComponentNode
         PhpNamespaceNode|null $namespace = null,
         array $members = [],
         array $modifiers = [],
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $name, $value, $namespace, $members, $modifiers, $noindex);
     }

--- a/src/Nodes/PhpConstNode.php
+++ b/src/Nodes/PhpConstNode.php
@@ -20,7 +20,7 @@ final class PhpConstNode extends PhpMemberNode
         array                           $value = [],
         private readonly array $modifiers = [],
         private readonly string|null    $phpType = null,
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $memberName->toString(), $value, null, $noindex);
     }

--- a/src/Nodes/PhpEnumNode.php
+++ b/src/Nodes/PhpEnumNode.php
@@ -23,7 +23,7 @@ final class PhpEnumNode extends PhpComponentNode
         array $members = [],
         array $modifiers = [],
         private readonly ?string $phpType = null,
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $name, $value, $namespace, $members, $modifiers, $noindex);
     }

--- a/src/Nodes/PhpExceptionNode.php
+++ b/src/Nodes/PhpExceptionNode.php
@@ -21,7 +21,7 @@ final class PhpExceptionNode extends PhpComponentNode
         PhpNamespaceNode|null $namespace = null,
         array $members = [],
         array $modifiers = [],
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $name, $value, $namespace, $members, $modifiers, $noindex);
     }

--- a/src/Nodes/PhpGlobalNode.php
+++ b/src/Nodes/PhpGlobalNode.php
@@ -24,7 +24,7 @@ final class PhpGlobalNode extends CompoundNode implements LinkTargetNode, Option
         private readonly string $id,
         private readonly string $name,
         array $value = [],
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($value);
     }

--- a/src/Nodes/PhpInterfaceNode.php
+++ b/src/Nodes/PhpInterfaceNode.php
@@ -19,7 +19,7 @@ final class PhpInterfaceNode extends PhpComponentNode
         array $value = [],
         PhpNamespaceNode|null $namespace = null,
         array $members = [],
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $name, $value, $namespace, $members, [], $noindex);
     }

--- a/src/Nodes/PhpMethodNode.php
+++ b/src/Nodes/PhpMethodNode.php
@@ -20,7 +20,7 @@ final class PhpMethodNode extends PhpMemberNode
         array $value = [],
         private readonly array $modifiers = [],
         private readonly CollectionNode|null $returnsDescription = null,
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $methodName->toString(), $value, null, $noindex);
     }

--- a/src/Nodes/PhpPropertyNode.php
+++ b/src/Nodes/PhpPropertyNode.php
@@ -20,7 +20,7 @@ final class PhpPropertyNode extends PhpMemberNode
         array                           $value = [],
         private readonly string|null    $phpType = null,
         private readonly array          $modifiers = [],
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $memberName->toString(), $value, null, $noindex);
     }

--- a/src/Nodes/PhpTraitNode.php
+++ b/src/Nodes/PhpTraitNode.php
@@ -19,7 +19,7 @@ final class PhpTraitNode extends PhpComponentNode
         array $value = [],
         PhpNamespaceNode|null $namespace = null,
         array $members = [],
-        readonly bool $noindex = false,
+        public readonly bool $noindex = false,
     ) {
         parent::__construct($id, self::TYPE, $name, $value, $namespace, $members, [], $noindex);
     }

--- a/src/PhpDomain/MethodNameService.php
+++ b/src/PhpDomain/MethodNameService.php
@@ -23,7 +23,7 @@ class MethodNameService
     {
         if (preg_match(self::METHOD_SIGNATURE_REGEX, $name, $matches)) {
             $methodName = $matches[1];
-            $parameters = $matches[2] ?? '';
+            $parameters = $matches[2];
             $returnType = $matches[3] ?? null;
             $parametersArray = preg_split('/\s*,\s*/', $parameters, -1, PREG_SPLIT_NO_EMPTY);
             if ($parametersArray === false) {

--- a/src/TextRoles/PhpComponentTextRole.php
+++ b/src/TextRoles/PhpComponentTextRole.php
@@ -63,7 +63,9 @@ abstract class PhpComponentTextRole implements TextRole
     /** @return array{text:?string,uri:string} */
     private function extractEmbeddedUri(string $text): array
     {
-        preg_match(self::TEXTROLE_LINK_REGEX, $text, $matches);
+        if (preg_match(self::TEXTROLE_LINK_REGEX, $text, $matches) !== 1) {
+            return ['text' => null, 'uri' => $text];
+        }
 
         $text = $matches[1] === '' ? null : $matches[1];
         $uri = $matches[1];


### PR DESCRIPTION
## Why

`guides-php-domain` does not commit a `composer.lock` (correct for a library), so CI resolves dependencies fresh on every run (`ramsey/composer-install` with `require-lock-file: false`). The latest tooling has drifted past the code, and `main` is red:

| Job | Failure |
|---|---|
| Build PHP (8.1 / 8.2) | `test-integration` fatal: `Class "League\Flysystem\Adapter\Local" not found` |
| Quality | `code-style` — php-cs-fixer finds violations (Error 8) |
| Quality | `phpstan` fails once code-style passes (two errors from the freshly resolved PHPStan) |

## What

Minimal changes to get CI green again — proper CI hardening (e.g. pinning tooling) can follow:

- **Require `phpdocumentor/guides-cli: ^1.0`** (was `^0.3`). guides-cli 0.3.x uses the Flysystem **v1** API (`League\Flysystem\Adapter\Local`, `addPlugin`), but Flysystem v1 does not support PHP 8.1+, so the fresh resolve installs Flysystem v3 and the integration tests fatal. guides-cli 1.9.x uses the v3 API. **guides core stays 1.10.1, so the rendered output is unchanged — no snapshot updates needed** (all 48 integration tests pass as-is).
- **`public readonly`** on promoted constructor properties (php-cs-fixer `visibility_required`), 12 files.
- **Fixed the two PHPStan errors in place** (no baseline change): a redundant `?? ''` on a regex offset that always exists, and an unguarded `preg_match()` result.

The PHPStan baseline is left untouched.

## Verified

CI resolves a different dependency set per PHP version, so this was checked against **both**: resolved as PHP 8.1 → symfony/console 6.4, and as PHP 8.2 → symfony/console 7.4. On each, `composer normalize`, `code-style`, `phpstan` (level max), `test-integration` (48 tests) and `test-unit` (6 tests) are green.

(Note: PHP 8.4+ would resolve symfony/console 8, which PHPStan 1.12 cannot parse — but that combination cannot occur on the 8.1/8.2 CI matrix.)
