### PR TITLE
[TASK] Test against PHP 8.2-8.5 and drop 8.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,8 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4'
+          - '8.5'
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -31,7 +33,7 @@ jobs:
         with:
           dependency-versions: "locked"
       - name: "Lint PHP"
-        run: find . -type f -name '*.php' ! -path "./.Build/*" -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
+        run: find . -type f -name '*.php' ! -path "./.Build/*" ! -path "./vendor/*" -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
       - name: "Run unit tests"
         run: make test-unit
       - name: "Run integration tests"
@@ -46,7 +48,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           php-extensions: ''
       - name: "Install dependencies with Composer"
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "type": "library",
     "homepage": "https://docs.typo3.org",
     "require": {
+        "php": "^8.2",
         "phpdocumentor/guides": "^1.0",
         "phpdocumentor/guides-restructured-text": "^1.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ rules:
   - Symplify\PHPStanRules\Rules\AnnotateRegexClassConstWithRegexLinkRule
   - Symplify\PHPStanRules\Rules\RegexSuffixInRegexConstantRule
 parameters:
-  phpVersion: 80100
+  phpVersion: 80200
   level: max
   strictRules:
     allRules: false


### PR DESCRIPTION
## What

Raise the supported PHP floor to **8.2** and align the CI matrix with the sole consumer, **render-guides** (which tests PHP 8.2-8.5).

- **`.github/workflows/main.yaml`** —
  - Build PHP matrix `8.1, 8.2` → `8.2, 8.3, 8.4, 8.5`;
  - the Quality job (composer normalize, code-style, PHPStan) moves from a hardcoded `8.1` to `8.2`;
  - the **Lint** step no longer lints `vendor/` — third-party code (e.g. the pinned `rector 0.19.1`, `phpdocumentor/filesystem`, `localheinz/diff`) trips `php -l`'s *implicitly-nullable-parameter* deprecation on PHP 8.4+, and that deprecation goes to **stdout**, so the lint grep treats it as a failure. Only the project's own code should be syntax-checked.
- **`composer.json`** — declare `"php": "^8.2"`.
- **`phpstan.neon`** — `phpVersion` `80100` → `80200`.

## Why no Symfony-8 / PHPStan trouble

The repo commits no `composer.lock`, so each leg resolves fresh: PHP 8.4/8.5 pull **Symfony 8** (it requires PHP ≥8.4.1), which **PHPStan 1.12 cannot parse**. But static analysis runs in the **Quality job on a single PHP version (8.2)**, where the resolve installs **Symfony 7** — so PHPStan is unaffected. The **runtime** tests run across the whole matrix and pass on Symfony 8 too. No symfony cap and no PHPStan-2 upgrade are needed for this step.

## Verified locally — fresh resolve per PHP version

| PHP | symfony/console | lint | unit | integration | quality |
|---|---|---|---|---|---|
| 8.2 | 7.4.13 | ✅ | ✅ 6 | ✅ 48 | ✅ phpstan + cs + normalize |
| 8.3 | 7.4.13 | ✅ | ✅ 6 | ✅ 48 | — |
| 8.4 | 8.1.0 | ✅ | ✅ 6 | ✅ 48 | — |
| 8.5 | 8.1.0 | ✅ | ✅ 6 | ✅ 48 | — |
